### PR TITLE
Null Checks & Cleanups

### DIFF
--- a/.github/workflows/publishing.yaml
+++ b/.github/workflows/publishing.yaml
@@ -1,36 +1,41 @@
 name: Publishing
 
-on:
-  push:
-    tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+on: push
 
 jobs:
-  pypi:
-    name: Publish to PyPI
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version:
-          - '3.12'
-        os:
-          - ubuntu-latest
-    runs-on: ${{ matrix.os }}
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
     steps:
-      #----------------------------------------------
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      #----------------------------------------------
-      - name: Setup python
-        uses: actions/setup-python@v5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
-      - name: Setup environment
-        run: pip install twine build packaging
-      #----------------------------------------------
-      - name: Build project
+          python-version: '3.12'
+      - name: Install pypa/build
+        run: pip install build
+      - name: Build a binary wheel and a source tarball
         run: python -m build
-      - name: Check dist
-        run: twine check dist/*
-      - name: Publish project
-        run: twine upload --username __token__ --password ${{ secrets.PYPI_TOKEN }} dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-to-pypi:
+    name: Publish to PyPI
+    if: startsWith(github.ref, 'refs/tags/')
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/perdoo
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Pre-Commit](https://img.shields.io/badge/Pre--Commit-informational?style=flat-square&logo=pre-commit&labelColor=grey)](https://github.com/pre-commit/pre-commit)
 [![Ruff](https://img.shields.io/badge/Ruff-informational?style=flat-square&logo=ruff&labelColor=grey)](https://github.com/astral-sh/ruff)
 
-[![Github - Contributors](https://img.shields.io/github/contributors/ComicCorps/Perdoo.svg?logo=Github&label=Contributors&style=flat-square)](https://github.com/ComicCorps/Perdoo/graphs/contributors)
+[![Github - Contributors](https://img.shields.io/github/contributors/Buried-In-Code/Perdoo.svg?logo=Github&label=Contributors&style=flat-square)](https://github.com/Buried-In-Code/Perdoo/graphs/contributors)
 
 Perdoo is designed to assist in sorting and organizing your comic collection by utilizing metadata files stored within comic archives.\
 Perdoo standardizes all your digital comics into a unified format (cb7, cbt, or cbz).\
@@ -18,20 +18,15 @@ Unlike other tagging tools, Perdoo employs a manual approach when metadata files
 
 ## Installation
 
-### PyPI
-
-1. Ensure you have a supported version of [Python](https://www.python.org/) installed: `python --version`
-2. Install the project from PyPI: `pip install perdoo`
-
 ### Pipx
 
 1. Ensure you have [Pipx](https://pipxproject.github.io/pipx/) installed: `pipx --version`
 2. Install the project: `pipx install perdoo`
 
-### GitHub
+### From Source
 
 1. Ensure you have a supported version of [Python](https://www.python.org/) installed: `python --version`
-2. Clone the repository: `git clone https://github.com/ComicCorps/Perdoo`
+2. Clone the repository: `git clone https://github.com/Buried-In-Code/Perdoo`
 3. Install the project: `pip install .`
 
 ## Execution
@@ -63,14 +58,14 @@ Unlike other tagging tools, Perdoo employs a manual approach when metadata files
 
 ### Metadata Files
 
-- [Metadata.xml](https://github.com/ComicCorps/Schemas)
+- [Metadata.xml](https://github.com/Buried-In-Code/Schemas)
 - [MetronInfo.xml](https://github.com/Metron-Project/metroninfo)
-- [ComicInfo.xml](https://github.com/anansi-project/comicinfo)
+- Perdoo supports a slightly modified [ComicInfo.xml](https://github.com/anansi-project/comicinfo) to ignore field ordering. _See [Buried-In-Code/Schemas](https://github.com/Buried-In-Code/Schemas) for details._
 
 ## Services
 
 - [Comicvine](https://comicvine.gamespot.com) using the [Simyan](https://github.com/Metron-Project/Simyan) library.
-- [League of Comic Geeks](https://leagueofcomicgeeks.com) using the [Himon](https://github.com/ComicCorps/Himon) library.
+- [League of Comic Geeks](https://leagueofcomicgeeks.com) using the [Himon](https://github.com/Buried-In-Code/Himon) library.
 - [Marvel](https://www.marvel.com/comics) using the [Esak](https://github.com/Metron-Project/Esak) library.
 - [Metron](https://metron.cloud) using the [Mokkari](https://github.com/Metron-Project/Mokkari) library.
 
@@ -114,4 +109,5 @@ Collection Root
 
 ## Socials
 
+[![Social - Fosstodon](https://img.shields.io/badge/%40BuriedInCode-teal?label=Fosstodon&logo=mastodon&style=for-the-badge)](https://fosstodon.org/@BuriedInCode)\
 [![Social - Matrix](https://img.shields.io/matrix/The-Dev-Environment:matrix.org?label=The-Dev-Environment&logo=matrix&style=for-the-badge)](https://matrix.to/#/#The-Dev-Environment:matrix.org)

--- a/perdoo/__init__.py
+++ b/perdoo/__init__.py
@@ -2,12 +2,12 @@ __all__ = [
     "__version__",
     "ARCHIVE_EXTENSIONS",
     "IMAGE_EXTENSIONS",
-    "get_cache_dir",
-    "get_config_dir",
-    "get_data_dir",
+    "get_cache_root",
+    "get_config_root",
+    "get_data_root",
     "setup_logging",
 ]
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 import logging
 import os
@@ -22,34 +22,34 @@ ARCHIVE_EXTENSIONS = (".cb7", ".cbr", ".cbt", ".cbz")
 IMAGE_EXTENSIONS = (".jpg", ".jpeg", ".png", ".webp")
 
 
-def get_cache_dir() -> Path:
+def get_cache_root() -> Path:
     cache_home = os.getenv("XDG_CACHE_HOME", default=str(Path.home() / ".cache"))
     folder = Path(cache_home).resolve() / "perdoo"
     folder.mkdir(exist_ok=True, parents=True)
     return folder
 
 
-def get_config_dir() -> Path:
+def get_config_root() -> Path:
     config_home = os.getenv("XDG_CONFIG_HOME", default=str(Path.home() / ".config"))
     folder = Path(config_home).resolve() / "perdoo"
     folder.mkdir(exist_ok=True, parents=True)
     return folder
 
 
-def get_data_dir() -> Path:
+def get_data_root() -> Path:
     data_home = os.getenv("XDG_DATA_HOME", default=str(Path.home() / ".local" / "share"))
     folder = Path(data_home).resolve() / "perdoo"
     folder.mkdir(exist_ok=True, parents=True)
     return folder
 
 
-def get_project_dir() -> Path:
+def get_project_root() -> Path:
     return Path(__file__).parent.parent
 
 
 def setup_logging(debug: bool = False) -> None:
     install(show_locals=True, max_frames=6, console=CONSOLE)
-    log_folder = get_project_dir() / "logs"
+    log_folder = get_project_root() / "logs"
     log_folder.mkdir(parents=True, exist_ok=True)
 
     console_handler = RichHandler(

--- a/perdoo/__main__.py
+++ b/perdoo/__main__.py
@@ -321,6 +321,9 @@ def start(settings: Settings, force: bool = False) -> None:
         )
 
         metadata, metron_info, comic_info = fetch_from_services(settings=settings, details=details)
+        if not metadata:
+            LOGGER.warning("Not enough information to organize and rename this comic, skipping")
+            continue
         new_file = generate_filename(
             root=settings.output_folder, extension=settings.output.format.value, metadata=metadata
         )
@@ -341,11 +344,11 @@ def start(settings: Settings, force: bool = False) -> None:
                 metadata_file = temp_folder / "Metadata.xml"
                 metadata.to_file(file=metadata_file)
                 files.append(metadata_file)
-            if settings.output.create_metron_info:
+            if metron_info and settings.output.create_metron_info:
                 metron_info_file = temp_folder / "MetronInfo.xml"
                 metron_info.to_file(file=metron_info_file)
                 files.append(metron_info_file)
-            if settings.output.create_comic_info:
+            if comic_info and settings.output.create_comic_info:
                 comic_info_file = temp_folder / "ComicInfo.xml"
                 comic_info.to_file(file=comic_info_file)
                 files.append(comic_info_file)

--- a/perdoo/models/comic_info.py
+++ b/perdoo/models/comic_info.py
@@ -327,7 +327,7 @@ class ComicInfo(PascalModel, InfoModel):
         content = self.clean_contents(content)
         content["@xmlns:xsi"] = "http://www.w3.org/2001/XMLSchema-instance"
         content["@xsi:noNamespaceSchemaLocation"] = (
-            "https://raw.githubusercontent.com/ComicCorps/Schemas/main/schemas/v2.0/ComicInfo.xsd"
+            "https://raw.githubusercontent.com/Buried-In-Code/Schemas/main/schemas/v2.0/ComicInfo.xsd"
         )
 
         with file.open("wb") as stream:

--- a/perdoo/models/metadata.py
+++ b/perdoo/models/metadata.py
@@ -355,7 +355,7 @@ class Metadata(PascalModel, InfoModel):
         content = self.clean_contents(content)
         content["@xmlns:xsi"] = "http://www.w3.org/2001/XMLSchema-instance"
         content["@xsi:noNamespaceSchemaLocation"] = (
-            "https://raw.githubusercontent.com/ComicCorps/Schemas/main/drafts/v1.0/Metadata.xsd"
+            "https://raw.githubusercontent.com/Buried-In-Code/Schemas/main/drafts/v1.0/Metadata.xsd"
         )
 
         with file.open("wb") as stream:

--- a/perdoo/services/comicvine.py
+++ b/perdoo/services/comicvine.py
@@ -14,7 +14,7 @@ from simyan.schemas.issue import Issue
 from simyan.schemas.volume import Volume
 from simyan.sqlite_cache import SQLiteCache
 
-from perdoo import get_cache_dir
+from perdoo import get_cache_root
 from perdoo.console import CONSOLE, create_menu
 from perdoo.models import ComicInfo, Metadata, MetronInfo
 from perdoo.models.metadata import Source
@@ -28,7 +28,7 @@ LOGGER = logging.getLogger(__name__)
 
 class Comicvine(BaseService[Volume, Issue]):
     def __init__(self: Comicvine, settings: ComicvineSettings):
-        cache = SQLiteCache(path=get_cache_dir() / "simyan.sqlite", expiry=14)
+        cache = SQLiteCache(path=get_cache_root() / "simyan.sqlite", expiry=14)
         self.session = Simyan(api_key=settings.api_key, cache=cache)
 
     def _get_series_id(self: Comicvine, title: str | None) -> int | None:

--- a/perdoo/services/league.py
+++ b/perdoo/services/league.py
@@ -9,7 +9,7 @@ from himon.schemas.comic import Comic
 from himon.schemas.series import Series
 from himon.sqlite_cache import SQLiteCache
 
-from perdoo import get_cache_dir
+from perdoo import get_cache_root
 from perdoo.models import ComicInfo, Metadata, MetronInfo
 from perdoo.services._base import BaseService
 from perdoo.settings import LeagueofComicGeeks as LeagueSettings
@@ -20,7 +20,7 @@ LOGGER = logging.getLogger(__name__)
 
 class League(BaseService[Series, Comic]):
     def __init__(self: League, settings: LeagueSettings):
-        cache = SQLiteCache(path=get_cache_dir() / "himon.sqlite", expiry=14)
+        cache = SQLiteCache(path=get_cache_root() / "himon.sqlite", expiry=14)
         self.session = Himon(
             client_id=settings.client_id,
             client_secret=settings.client_secret,

--- a/perdoo/services/marvel.py
+++ b/perdoo/services/marvel.py
@@ -13,7 +13,7 @@ from esak.sqlite_cache import SqliteCache
 from pydantic import HttpUrl
 from rich.prompt import Confirm, Prompt
 
-from perdoo import get_cache_dir
+from perdoo import get_cache_root
 from perdoo.console import CONSOLE, create_menu
 from perdoo.models import ComicInfo, Metadata, MetronInfo
 from perdoo.services._base import BaseService
@@ -25,7 +25,7 @@ LOGGER = logging.getLogger(__name__)
 
 class Marvel(BaseService[Series, Comic]):
     def __init__(self: Marvel, settings: MarvelSettings):
-        cache = SqliteCache(db_name=str(get_cache_dir() / "esak.sqlite"), expire=14)
+        cache = SqliteCache(db_name=str(get_cache_root() / "esak.sqlite"), expire=14)
         self.session = Esak(
             public_key=settings.public_key, private_key=settings.private_key, cache=cache
         )

--- a/perdoo/services/metron.py
+++ b/perdoo/services/metron.py
@@ -13,7 +13,7 @@ from mokkari.sqlite_cache import SqliteCache
 from pydantic import HttpUrl
 from rich.prompt import Confirm, Prompt
 
-from perdoo import get_cache_dir
+from perdoo import get_cache_root
 from perdoo.console import CONSOLE, create_menu
 from perdoo.models import ComicInfo, Metadata, MetronInfo
 from perdoo.models.metadata import Source
@@ -27,7 +27,7 @@ LOGGER = logging.getLogger(__name__)
 
 class Metron(BaseService[Series, Issue]):
     def __init__(self: Metron, settings: MetronSettings):
-        cache = SqliteCache(db_name=str(get_cache_dir() / "mokkari.sqlite"), expire=14)
+        cache = SqliteCache(db_name=str(get_cache_root() / "mokkari.sqlite"), expire=14)
         self.session = Mokkari(username=settings.username, passwd=settings.password, cache=cache)
 
     def _get_series_via_comicvine(self: Metron, comicvine_id: int | None) -> int | None:

--- a/perdoo/settings.py
+++ b/perdoo/settings.py
@@ -19,7 +19,7 @@ from typing import ClassVar
 import tomli_w as tomlwriter
 from pydantic import BaseModel, field_validator
 
-from perdoo import get_config_dir, get_data_dir
+from perdoo import get_config_root, get_data_root
 
 try:
     import tomllib as tomlreader  # Python >= 3.11
@@ -116,9 +116,9 @@ class Output(SettingsModel):
 
 
 class Settings(SettingsModel):
-    _filename: ClassVar[Path] = get_config_dir() / "settings.toml"
-    input_folder: Path = get_data_dir()
-    output_folder: Path = get_data_dir()
+    _filename: ClassVar[Path] = get_config_root() / "settings.toml"
+    input_folder: Path = get_data_root()
+    output_folder: Path = get_data_root()
     comicvine: Comicvine = Comicvine()
     league_of_comic_geeks: LeagueofComicGeeks = LeagueofComicGeeks()
     marvel: Marvel = Marvel()
@@ -141,7 +141,7 @@ class Settings(SettingsModel):
 
     def save(self: Settings) -> Settings:
         with self._filename.open("wb") as stream:
-            content = self.dict(by_alias=False)
+            content = self.model_dump(by_alias=False)
             content["input_folder"] = str(content["input_folder"])
             content["output_folder"] = str(content["output_folder"])
             content["service_order"] = [str(x) for x in content["service_order"]]


### PR DESCRIPTION
- Fix for #19 
- Update PyPI publishing
- Refine README
- Rename `get_cache_dir()` to `get_cache_root()`
- Rename `get_config_dir()` to `get_config_root()`
- Rename `get_data_dir()` to `get_data_root()`
- Rename `get_project_dir()` to `get_project_root()`