### PR TITLE
Custom Seperator

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@ repos:
         args:
           - --number
           - --wrap=keep
+        exclude: ".github\/ISSUE_TEMPLATE\/.*.md"
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
@@ -38,6 +39,10 @@ repos:
         args:
           - --fix=auto
       - id: name-tests-test
+      - id: pretty-format-json
+        args:
+          - --autofix
+          - --indent=2
       - id: trailing-whitespace
         args:
           - --markdown-linebreak-ext=md

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
 [![Github Action - Testing](https://img.shields.io/github/actions/workflow/status/Buried-In-Code/Perdoo/testing.yaml?branch=main&logo=Github&label=Testing&style=flat-square)](https://github.com/Buried-In-Code/Perdoo/actions/workflows/testing.yaml)
 [![Github Action - Publishing](https://img.shields.io/github/actions/workflow/status/Buried-In-Code/Perdoo/publishing.yaml?branch=main&logo=Github&label=Publishing&style=flat-square)](https://github.com/Buried-In-Code/Perdoo/actions/workflows/publishing.yaml)
 
-
 Perdoo is designed to assist in sorting and organizing your comic collection by utilizing metadata files stored within comic archives.\
 Perdoo standardizes all your digital comics into a unified format (cbz).\
 It adds and/or updates metadata files using supported services.\
@@ -135,6 +134,92 @@ Naming is done based on the Comic Format, set the value to `""` and it will fall
 | `{title}`            | The issue title.                                       |
 | `{upc}`              | The issue's UPC.                                       |
 | `{volume}`           | The volume of the series.                              |
+
+## Settings
+
+To set Perdoo setting details, update the file: `~/.config/perdoo/settings.toml`.
+File will be created on first run.
+
+### Example File
+
+```toml
+[output]
+folder = "~/.local/share/perdoo"
+format = "cbz"
+
+[output.comic_info]
+create = true
+handle_pages = true
+
+[output.metron_info]
+create = true
+
+[output.naming]
+seperator = "-"
+default = "{publisher-name}/{series-name}-v{volume}/{series-name}-v{volume}_#{number:3}"
+annual = ""
+digital_chapter = ""
+graphic_novel = ""
+hardcover = ""
+limited_series = ""
+omnibus = ""
+one_shot = ""
+single_issue = ""
+trade_paperback = ""
+
+[services]
+order = ["Metron", "Marvel", "Comicvine"]
+
+[services.comicvine]
+api_key = "<Comicvine API Key>"
+
+[services.marvel]
+public_key = "<Marvel Public Key>"
+private_key = "<Marvel Private Key>"
+
+[services.metron]
+username = "<Metron Username>"
+password = "<Metron Password>"
+
+```
+
+### Details
+
+- `output.folder`
+  The folder where the output files will be stored.
+  Defaults to `~/.local/share/perdoo`.
+
+- `output.format`
+  The output file format for the comic archives.
+  Defaults to `cbz`.
+
+- `output.comic_info.create`
+  Whether to create a ComicInfo.xml file in the output archive.
+  Defaults to `true`.
+
+- `output.comic_info.handle_pages`
+  Whether to handle page data in the ComicInfo.xml file.
+  Defaults to `true`.
+
+- `output.metron_info.create`
+  Whether to create a MetronInfo.xml file in the output archive.
+  Defaults to `true`.
+
+- `output.naming.seperator`
+  The word separator used in the output file names.
+  Defaults to `-`.
+  Options are `-`, `_`, `.`, or ` ` (space).
+
+- `output.naming.*`
+  The naming patterns for different comic formats.
+  Each pattern can be customized or left empty to use the default setting.
+  The patterns support various metadata fields as described in the above "File Renaming and Organization" section.
+
+- `services.order`
+  The order in which the services will be used for metadata retrieval.
+  Metadata will be fetched from the first service that returns a result.
+  Don't include the service name in the list if you don't want to use it.
+  Defaults to `["Metron", "Marvel", "Comicvine"]`, options are `Metron`, `Marvel` and `Comicvine`.
 
 ## Socials
 

--- a/docs/img/perdoo-archive-view.svg
+++ b/docs/img/perdoo-archive-view.svg
@@ -1,4 +1,4 @@
-<svg class="rich-terminal" viewBox="0 0 2166 391.59999999999997" xmlns="http://www.w3.org/2000/svg">
+<svg class="rich-terminal" viewBox="0 0 994 416.0" xmlns="http://www.w3.org/2000/svg">
     <!-- Generated with Rich https://www.textualize.io -->
     <style>
 
@@ -19,91 +19,101 @@
         font-weight: 700;
     }
 
-    .terminal-884249335-matrix {
+    .terminal-3334976758-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-884249335-title {
+    .terminal-3334976758-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-884249335-r1 { fill: #c5c8c6 }
+    .terminal-3334976758-r1 { fill: #c5c8c6;font-weight: bold }
+.terminal-3334976758-r2 { fill: #c5c8c6 }
+.terminal-3334976758-r3 { fill: #d0b344;font-weight: bold }
+.terminal-3334976758-r4 { fill: #868887 }
+.terminal-3334976758-r5 { fill: #cc555a }
+.terminal-3334976758-r6 { fill: #8a4346 }
+.terminal-3334976758-r7 { fill: #68a0b3;font-weight: bold }
     </style>
 
     <defs>
-    <clipPath id="terminal-884249335-clip-terminal">
-      <rect x="0" y="0" width="2146.2" height="340.59999999999997" />
+    <clipPath id="terminal-3334976758-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="365.0" />
     </clipPath>
-    <clipPath id="terminal-884249335-line-0">
-    <rect x="0" y="1.5" width="2147.2" height="24.65"/>
+    <clipPath id="terminal-3334976758-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-1">
-    <rect x="0" y="25.9" width="2147.2" height="24.65"/>
+<clipPath id="terminal-3334976758-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-2">
-    <rect x="0" y="50.3" width="2147.2" height="24.65"/>
+<clipPath id="terminal-3334976758-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-3">
-    <rect x="0" y="74.7" width="2147.2" height="24.65"/>
+<clipPath id="terminal-3334976758-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-4">
-    <rect x="0" y="99.1" width="2147.2" height="24.65"/>
+<clipPath id="terminal-3334976758-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-5">
-    <rect x="0" y="123.5" width="2147.2" height="24.65"/>
+<clipPath id="terminal-3334976758-line-5">
+    <rect x="0" y="123.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-6">
-    <rect x="0" y="147.9" width="2147.2" height="24.65"/>
+<clipPath id="terminal-3334976758-line-6">
+    <rect x="0" y="147.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-7">
-    <rect x="0" y="172.3" width="2147.2" height="24.65"/>
+<clipPath id="terminal-3334976758-line-7">
+    <rect x="0" y="172.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-8">
-    <rect x="0" y="196.7" width="2147.2" height="24.65"/>
+<clipPath id="terminal-3334976758-line-8">
+    <rect x="0" y="196.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-9">
-    <rect x="0" y="221.1" width="2147.2" height="24.65"/>
+<clipPath id="terminal-3334976758-line-9">
+    <rect x="0" y="221.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-10">
-    <rect x="0" y="245.5" width="2147.2" height="24.65"/>
+<clipPath id="terminal-3334976758-line-10">
+    <rect x="0" y="245.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-11">
-    <rect x="0" y="269.9" width="2147.2" height="24.65"/>
+<clipPath id="terminal-3334976758-line-11">
+    <rect x="0" y="269.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-12">
-    <rect x="0" y="294.3" width="2147.2" height="24.65"/>
+<clipPath id="terminal-3334976758-line-12">
+    <rect x="0" y="294.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3334976758-line-13">
+    <rect x="0" y="318.7" width="976" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="2164" height="389.6" rx="8"/>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="414" rx="8"/>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-884249335-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-3334976758-clip-terminal)">
     
-    <g class="terminal-884249335-matrix">
-    <text class="terminal-884249335-r1" x="0" y="20" textLength="414.8" clip-path="url(#terminal-884249335-line-0)">Traceback&#160;(most&#160;recent&#160;call&#160;last):</text><text class="terminal-884249335-r1" x="2147.2" y="20" textLength="12.2" clip-path="url(#terminal-884249335-line-0)">
-</text><text class="terminal-884249335-r1" x="0" y="44.4" textLength="951.6" clip-path="url(#terminal-884249335-line-1)">&#160;&#160;File&#160;&quot;/home/runner/work/Perdoo/Perdoo/.venv/bin/Perdoo&quot;,&#160;line&#160;4,&#160;in&#160;&lt;module&gt;</text><text class="terminal-884249335-r1" x="2147.2" y="44.4" textLength="12.2" clip-path="url(#terminal-884249335-line-1)">
-</text><text class="terminal-884249335-r1" x="0" y="68.8" textLength="427" clip-path="url(#terminal-884249335-line-2)">&#160;&#160;&#160;&#160;from&#160;perdoo.__main__&#160;import&#160;app</text><text class="terminal-884249335-r1" x="2147.2" y="68.8" textLength="12.2" clip-path="url(#terminal-884249335-line-2)">
-</text><text class="terminal-884249335-r1" x="0" y="93.2" textLength="988.2" clip-path="url(#terminal-884249335-line-3)">&#160;&#160;File&#160;&quot;/home/runner/work/Perdoo/Perdoo/perdoo/__main__.py&quot;,&#160;line&#160;12,&#160;in&#160;&lt;module&gt;</text><text class="terminal-884249335-r1" x="2147.2" y="93.2" textLength="12.2" clip-path="url(#terminal-884249335-line-3)">
-</text><text class="terminal-884249335-r1" x="0" y="117.6" textLength="634.4" clip-path="url(#terminal-884249335-line-4)">&#160;&#160;&#160;&#160;from&#160;perdoo.cli&#160;import&#160;archive_app,&#160;settings_app</text><text class="terminal-884249335-r1" x="2147.2" y="117.6" textLength="12.2" clip-path="url(#terminal-884249335-line-4)">
-</text><text class="terminal-884249335-r1" x="0" y="142" textLength="1024.8" clip-path="url(#terminal-884249335-line-5)">&#160;&#160;File&#160;&quot;/home/runner/work/Perdoo/Perdoo/perdoo/cli/__init__.py&quot;,&#160;line&#160;3,&#160;in&#160;&lt;module&gt;</text><text class="terminal-884249335-r1" x="2147.2" y="142" textLength="12.2" clip-path="url(#terminal-884249335-line-5)">
-</text><text class="terminal-884249335-r1" x="0" y="166.4" textLength="646.6" clip-path="url(#terminal-884249335-line-6)">&#160;&#160;&#160;&#160;from&#160;perdoo.cli.archive&#160;import&#160;app&#160;as&#160;archive_app</text><text class="terminal-884249335-r1" x="2147.2" y="166.4" textLength="12.2" clip-path="url(#terminal-884249335-line-6)">
-</text><text class="terminal-884249335-r1" x="0" y="190.8" textLength="1012.6" clip-path="url(#terminal-884249335-line-7)">&#160;&#160;File&#160;&quot;/home/runner/work/Perdoo/Perdoo/perdoo/cli/archive.py&quot;,&#160;line&#160;8,&#160;in&#160;&lt;module&gt;</text><text class="terminal-884249335-r1" x="2147.2" y="190.8" textLength="12.2" clip-path="url(#terminal-884249335-line-7)">
-</text><text class="terminal-884249335-r1" x="0" y="215.2" textLength="414.8" clip-path="url(#terminal-884249335-line-8)">&#160;&#160;&#160;&#160;from&#160;perdoo.comic&#160;import&#160;Comic</text><text class="terminal-884249335-r1" x="2147.2" y="215.2" textLength="12.2" clip-path="url(#terminal-884249335-line-8)">
-</text><text class="terminal-884249335-r1" x="0" y="239.6" textLength="951.6" clip-path="url(#terminal-884249335-line-9)">&#160;&#160;File&#160;&quot;/home/runner/work/Perdoo/Perdoo/perdoo/comic.py&quot;,&#160;line&#160;14,&#160;in&#160;&lt;module&gt;</text><text class="terminal-884249335-r1" x="2147.2" y="239.6" textLength="12.2" clip-path="url(#terminal-884249335-line-9)">
-</text><text class="terminal-884249335-r1" x="0" y="264" textLength="439.2" clip-path="url(#terminal-884249335-line-10)">&#160;&#160;&#160;&#160;from&#160;darkseid.archivers&#160;import&#160;(</text><text class="terminal-884249335-r1" x="2147.2" y="264" textLength="12.2" clip-path="url(#terminal-884249335-line-10)">
-</text><text class="terminal-884249335-r1" x="0" y="288.4" textLength="231.8" clip-path="url(#terminal-884249335-line-11)">&#160;&#160;&#160;&#160;...&lt;6&#160;lines&gt;...</text><text class="terminal-884249335-r1" x="2147.2" y="288.4" textLength="12.2" clip-path="url(#terminal-884249335-line-11)">
-</text><text class="terminal-884249335-r1" x="0" y="312.8" textLength="61" clip-path="url(#terminal-884249335-line-12)">&#160;&#160;&#160;&#160;)</text><text class="terminal-884249335-r1" x="2147.2" y="312.8" textLength="12.2" clip-path="url(#terminal-884249335-line-12)">
-</text><text class="terminal-884249335-r1" x="0" y="337.2" textLength="2147.2" clip-path="url(#terminal-884249335-line-13)">ImportError:&#160;cannot&#160;import&#160;name&#160;&#x27;SevenZipArchiver&#x27;&#160;from&#160;&#x27;darkseid.archivers&#x27;&#160;(/home/runner/work/Perdoo/Perdoo/.venv/lib/python3.13/site-packages/darkseid/archivers/__init__.py)</text><text class="terminal-884249335-r1" x="2147.2" y="337.2" textLength="12.2" clip-path="url(#terminal-884249335-line-13)">
+    <g class="terminal-3334976758-matrix">
+    <text class="terminal-3334976758-r2" x="976" y="20" textLength="12.2" clip-path="url(#terminal-3334976758-line-0)">
+</text><text class="terminal-3334976758-r3" x="12.2" y="44.4" textLength="85.4" clip-path="url(#terminal-3334976758-line-1)">Usage:&#160;</text><text class="terminal-3334976758-r1" x="97.6" y="44.4" textLength="439.2" clip-path="url(#terminal-3334976758-line-1)">Perdoo&#160;archive&#160;view&#160;[OPTIONS]&#160;TARGET</text><text class="terminal-3334976758-r2" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-3334976758-line-1)">
+</text><text class="terminal-3334976758-r2" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-3334976758-line-2)">
+</text><text class="terminal-3334976758-r2" x="0" y="93.2" textLength="976" clip-path="url(#terminal-3334976758-line-3)">&#160;View&#160;the&#160;ComicInfo/MetronInfo&#160;inside&#160;a&#160;Comic&#160;archive.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3334976758-r2" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-3334976758-line-3)">
+</text><text class="terminal-3334976758-r2" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-3334976758-line-4)">
+</text><text class="terminal-3334976758-r2" x="976" y="142" textLength="12.2" clip-path="url(#terminal-3334976758-line-5)">
+</text><text class="terminal-3334976758-r4" x="0" y="166.4" textLength="24.4" clip-path="url(#terminal-3334976758-line-6)">╭─</text><text class="terminal-3334976758-r4" x="24.4" y="166.4" textLength="134.2" clip-path="url(#terminal-3334976758-line-6)">&#160;Arguments&#160;</text><text class="terminal-3334976758-r4" x="158.6" y="166.4" textLength="793" clip-path="url(#terminal-3334976758-line-6)">─────────────────────────────────────────────────────────────────</text><text class="terminal-3334976758-r4" x="951.6" y="166.4" textLength="24.4" clip-path="url(#terminal-3334976758-line-6)">─╮</text><text class="terminal-3334976758-r2" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-3334976758-line-6)">
+</text><text class="terminal-3334976758-r4" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-3334976758-line-7)">│</text><text class="terminal-3334976758-r5" x="24.4" y="190.8" textLength="12.2" clip-path="url(#terminal-3334976758-line-7)">*</text><text class="terminal-3334976758-r2" x="36.6" y="190.8" textLength="195.2" clip-path="url(#terminal-3334976758-line-7)">&#160;&#160;&#160;&#160;target&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3334976758-r3" x="231.8" y="190.8" textLength="48.8" clip-path="url(#terminal-3334976758-line-7)">FILE</text><text class="terminal-3334976758-r2" x="280.6" y="190.8" textLength="341.6" clip-path="url(#terminal-3334976758-line-7)">&#160;&#160;Comic&#160;to&#160;view&#160;details&#160;of.&#160;</text><text class="terminal-3334976758-r6" x="622.2" y="190.8" textLength="122" clip-path="url(#terminal-3334976758-line-7)">[required]</text><text class="terminal-3334976758-r4" x="963.8" y="190.8" textLength="12.2" clip-path="url(#terminal-3334976758-line-7)">│</text><text class="terminal-3334976758-r2" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-3334976758-line-7)">
+</text><text class="terminal-3334976758-r4" x="0" y="215.2" textLength="976" clip-path="url(#terminal-3334976758-line-8)">╰──────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-3334976758-r2" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-3334976758-line-8)">
+</text><text class="terminal-3334976758-r4" x="0" y="239.6" textLength="24.4" clip-path="url(#terminal-3334976758-line-9)">╭─</text><text class="terminal-3334976758-r4" x="24.4" y="239.6" textLength="109.8" clip-path="url(#terminal-3334976758-line-9)">&#160;Options&#160;</text><text class="terminal-3334976758-r4" x="134.2" y="239.6" textLength="817.4" clip-path="url(#terminal-3334976758-line-9)">───────────────────────────────────────────────────────────────────</text><text class="terminal-3334976758-r4" x="951.6" y="239.6" textLength="24.4" clip-path="url(#terminal-3334976758-line-9)">─╮</text><text class="terminal-3334976758-r2" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-3334976758-line-9)">
+</text><text class="terminal-3334976758-r4" x="0" y="264" textLength="12.2" clip-path="url(#terminal-3334976758-line-10)">│</text><text class="terminal-3334976758-r7" x="24.4" y="264" textLength="12.2" clip-path="url(#terminal-3334976758-line-10)">-</text><text class="terminal-3334976758-r7" x="36.6" y="264" textLength="61" clip-path="url(#terminal-3334976758-line-10)">-hide</text><text class="terminal-3334976758-r7" x="97.6" y="264" textLength="134.2" clip-path="url(#terminal-3334976758-line-10)">-comic-info</text><text class="terminal-3334976758-r2" x="231.8" y="264" textLength="732" clip-path="url(#terminal-3334976758-line-10)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Don&#x27;t&#160;show&#160;the&#160;ComicInfo&#160;details.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3334976758-r4" x="963.8" y="264" textLength="12.2" clip-path="url(#terminal-3334976758-line-10)">│</text><text class="terminal-3334976758-r2" x="976" y="264" textLength="12.2" clip-path="url(#terminal-3334976758-line-10)">
+</text><text class="terminal-3334976758-r4" x="0" y="288.4" textLength="12.2" clip-path="url(#terminal-3334976758-line-11)">│</text><text class="terminal-3334976758-r7" x="24.4" y="288.4" textLength="12.2" clip-path="url(#terminal-3334976758-line-11)">-</text><text class="terminal-3334976758-r7" x="36.6" y="288.4" textLength="61" clip-path="url(#terminal-3334976758-line-11)">-hide</text><text class="terminal-3334976758-r7" x="97.6" y="288.4" textLength="146.4" clip-path="url(#terminal-3334976758-line-11)">-metron-info</text><text class="terminal-3334976758-r2" x="244" y="288.4" textLength="719.8" clip-path="url(#terminal-3334976758-line-11)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Don&#x27;t&#160;show&#160;the&#160;MetronInfo&#160;details.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3334976758-r4" x="963.8" y="288.4" textLength="12.2" clip-path="url(#terminal-3334976758-line-11)">│</text><text class="terminal-3334976758-r2" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-3334976758-line-11)">
+</text><text class="terminal-3334976758-r4" x="0" y="312.8" textLength="12.2" clip-path="url(#terminal-3334976758-line-12)">│</text><text class="terminal-3334976758-r7" x="24.4" y="312.8" textLength="12.2" clip-path="url(#terminal-3334976758-line-12)">-</text><text class="terminal-3334976758-r7" x="36.6" y="312.8" textLength="61" clip-path="url(#terminal-3334976758-line-12)">-help</text><text class="terminal-3334976758-r2" x="97.6" y="312.8" textLength="866.2" clip-path="url(#terminal-3334976758-line-12)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Show&#160;this&#160;message&#160;and&#160;exit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3334976758-r4" x="963.8" y="312.8" textLength="12.2" clip-path="url(#terminal-3334976758-line-12)">│</text><text class="terminal-3334976758-r2" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-3334976758-line-12)">
+</text><text class="terminal-3334976758-r4" x="0" y="337.2" textLength="976" clip-path="url(#terminal-3334976758-line-13)">╰──────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-3334976758-r2" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-3334976758-line-13)">
+</text><text class="terminal-3334976758-r2" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-3334976758-line-14)">
 </text>
     </g>
     </g>

--- a/docs/img/perdoo-commands.svg
+++ b/docs/img/perdoo-commands.svg
@@ -1,4 +1,4 @@
-<svg class="rich-terminal" viewBox="0 0 2166 391.59999999999997" xmlns="http://www.w3.org/2000/svg">
+<svg class="rich-terminal" viewBox="0 0 994 513.5999999999999" xmlns="http://www.w3.org/2000/svg">
     <!-- Generated with Rich https://www.textualize.io -->
     <style>
 
@@ -19,91 +19,115 @@
         font-weight: 700;
     }
 
-    .terminal-884249335-matrix {
+    .terminal-1750544253-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-884249335-title {
+    .terminal-1750544253-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-884249335-r1 { fill: #c5c8c6 }
+    .terminal-1750544253-r1 { fill: #c5c8c6;font-weight: bold }
+.terminal-1750544253-r2 { fill: #c5c8c6 }
+.terminal-1750544253-r3 { fill: #d0b344;font-weight: bold }
+.terminal-1750544253-r4 { fill: #868887 }
+.terminal-1750544253-r5 { fill: #68a0b3;font-weight: bold }
     </style>
 
     <defs>
-    <clipPath id="terminal-884249335-clip-terminal">
-      <rect x="0" y="0" width="2146.2" height="340.59999999999997" />
+    <clipPath id="terminal-1750544253-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="462.59999999999997" />
     </clipPath>
-    <clipPath id="terminal-884249335-line-0">
-    <rect x="0" y="1.5" width="2147.2" height="24.65"/>
+    <clipPath id="terminal-1750544253-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-1">
-    <rect x="0" y="25.9" width="2147.2" height="24.65"/>
+<clipPath id="terminal-1750544253-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-2">
-    <rect x="0" y="50.3" width="2147.2" height="24.65"/>
+<clipPath id="terminal-1750544253-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-3">
-    <rect x="0" y="74.7" width="2147.2" height="24.65"/>
+<clipPath id="terminal-1750544253-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-4">
-    <rect x="0" y="99.1" width="2147.2" height="24.65"/>
+<clipPath id="terminal-1750544253-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-5">
-    <rect x="0" y="123.5" width="2147.2" height="24.65"/>
+<clipPath id="terminal-1750544253-line-5">
+    <rect x="0" y="123.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-6">
-    <rect x="0" y="147.9" width="2147.2" height="24.65"/>
+<clipPath id="terminal-1750544253-line-6">
+    <rect x="0" y="147.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-7">
-    <rect x="0" y="172.3" width="2147.2" height="24.65"/>
+<clipPath id="terminal-1750544253-line-7">
+    <rect x="0" y="172.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-8">
-    <rect x="0" y="196.7" width="2147.2" height="24.65"/>
+<clipPath id="terminal-1750544253-line-8">
+    <rect x="0" y="196.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-9">
-    <rect x="0" y="221.1" width="2147.2" height="24.65"/>
+<clipPath id="terminal-1750544253-line-9">
+    <rect x="0" y="221.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-10">
-    <rect x="0" y="245.5" width="2147.2" height="24.65"/>
+<clipPath id="terminal-1750544253-line-10">
+    <rect x="0" y="245.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-11">
-    <rect x="0" y="269.9" width="2147.2" height="24.65"/>
+<clipPath id="terminal-1750544253-line-11">
+    <rect x="0" y="269.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-12">
-    <rect x="0" y="294.3" width="2147.2" height="24.65"/>
+<clipPath id="terminal-1750544253-line-12">
+    <rect x="0" y="294.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1750544253-line-13">
+    <rect x="0" y="318.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1750544253-line-14">
+    <rect x="0" y="343.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1750544253-line-15">
+    <rect x="0" y="367.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1750544253-line-16">
+    <rect x="0" y="391.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1750544253-line-17">
+    <rect x="0" y="416.3" width="976" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="2164" height="389.6" rx="8"/>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="511.6" rx="8"/>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-884249335-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-1750544253-clip-terminal)">
     
-    <g class="terminal-884249335-matrix">
-    <text class="terminal-884249335-r1" x="0" y="20" textLength="414.8" clip-path="url(#terminal-884249335-line-0)">Traceback&#160;(most&#160;recent&#160;call&#160;last):</text><text class="terminal-884249335-r1" x="2147.2" y="20" textLength="12.2" clip-path="url(#terminal-884249335-line-0)">
-</text><text class="terminal-884249335-r1" x="0" y="44.4" textLength="951.6" clip-path="url(#terminal-884249335-line-1)">&#160;&#160;File&#160;&quot;/home/runner/work/Perdoo/Perdoo/.venv/bin/Perdoo&quot;,&#160;line&#160;4,&#160;in&#160;&lt;module&gt;</text><text class="terminal-884249335-r1" x="2147.2" y="44.4" textLength="12.2" clip-path="url(#terminal-884249335-line-1)">
-</text><text class="terminal-884249335-r1" x="0" y="68.8" textLength="427" clip-path="url(#terminal-884249335-line-2)">&#160;&#160;&#160;&#160;from&#160;perdoo.__main__&#160;import&#160;app</text><text class="terminal-884249335-r1" x="2147.2" y="68.8" textLength="12.2" clip-path="url(#terminal-884249335-line-2)">
-</text><text class="terminal-884249335-r1" x="0" y="93.2" textLength="988.2" clip-path="url(#terminal-884249335-line-3)">&#160;&#160;File&#160;&quot;/home/runner/work/Perdoo/Perdoo/perdoo/__main__.py&quot;,&#160;line&#160;12,&#160;in&#160;&lt;module&gt;</text><text class="terminal-884249335-r1" x="2147.2" y="93.2" textLength="12.2" clip-path="url(#terminal-884249335-line-3)">
-</text><text class="terminal-884249335-r1" x="0" y="117.6" textLength="634.4" clip-path="url(#terminal-884249335-line-4)">&#160;&#160;&#160;&#160;from&#160;perdoo.cli&#160;import&#160;archive_app,&#160;settings_app</text><text class="terminal-884249335-r1" x="2147.2" y="117.6" textLength="12.2" clip-path="url(#terminal-884249335-line-4)">
-</text><text class="terminal-884249335-r1" x="0" y="142" textLength="1024.8" clip-path="url(#terminal-884249335-line-5)">&#160;&#160;File&#160;&quot;/home/runner/work/Perdoo/Perdoo/perdoo/cli/__init__.py&quot;,&#160;line&#160;3,&#160;in&#160;&lt;module&gt;</text><text class="terminal-884249335-r1" x="2147.2" y="142" textLength="12.2" clip-path="url(#terminal-884249335-line-5)">
-</text><text class="terminal-884249335-r1" x="0" y="166.4" textLength="646.6" clip-path="url(#terminal-884249335-line-6)">&#160;&#160;&#160;&#160;from&#160;perdoo.cli.archive&#160;import&#160;app&#160;as&#160;archive_app</text><text class="terminal-884249335-r1" x="2147.2" y="166.4" textLength="12.2" clip-path="url(#terminal-884249335-line-6)">
-</text><text class="terminal-884249335-r1" x="0" y="190.8" textLength="1012.6" clip-path="url(#terminal-884249335-line-7)">&#160;&#160;File&#160;&quot;/home/runner/work/Perdoo/Perdoo/perdoo/cli/archive.py&quot;,&#160;line&#160;8,&#160;in&#160;&lt;module&gt;</text><text class="terminal-884249335-r1" x="2147.2" y="190.8" textLength="12.2" clip-path="url(#terminal-884249335-line-7)">
-</text><text class="terminal-884249335-r1" x="0" y="215.2" textLength="414.8" clip-path="url(#terminal-884249335-line-8)">&#160;&#160;&#160;&#160;from&#160;perdoo.comic&#160;import&#160;Comic</text><text class="terminal-884249335-r1" x="2147.2" y="215.2" textLength="12.2" clip-path="url(#terminal-884249335-line-8)">
-</text><text class="terminal-884249335-r1" x="0" y="239.6" textLength="951.6" clip-path="url(#terminal-884249335-line-9)">&#160;&#160;File&#160;&quot;/home/runner/work/Perdoo/Perdoo/perdoo/comic.py&quot;,&#160;line&#160;14,&#160;in&#160;&lt;module&gt;</text><text class="terminal-884249335-r1" x="2147.2" y="239.6" textLength="12.2" clip-path="url(#terminal-884249335-line-9)">
-</text><text class="terminal-884249335-r1" x="0" y="264" textLength="439.2" clip-path="url(#terminal-884249335-line-10)">&#160;&#160;&#160;&#160;from&#160;darkseid.archivers&#160;import&#160;(</text><text class="terminal-884249335-r1" x="2147.2" y="264" textLength="12.2" clip-path="url(#terminal-884249335-line-10)">
-</text><text class="terminal-884249335-r1" x="0" y="288.4" textLength="231.8" clip-path="url(#terminal-884249335-line-11)">&#160;&#160;&#160;&#160;...&lt;6&#160;lines&gt;...</text><text class="terminal-884249335-r1" x="2147.2" y="288.4" textLength="12.2" clip-path="url(#terminal-884249335-line-11)">
-</text><text class="terminal-884249335-r1" x="0" y="312.8" textLength="61" clip-path="url(#terminal-884249335-line-12)">&#160;&#160;&#160;&#160;)</text><text class="terminal-884249335-r1" x="2147.2" y="312.8" textLength="12.2" clip-path="url(#terminal-884249335-line-12)">
-</text><text class="terminal-884249335-r1" x="0" y="337.2" textLength="2147.2" clip-path="url(#terminal-884249335-line-13)">ImportError:&#160;cannot&#160;import&#160;name&#160;&#x27;SevenZipArchiver&#x27;&#160;from&#160;&#x27;darkseid.archivers&#x27;&#160;(/home/runner/work/Perdoo/Perdoo/.venv/lib/python3.13/site-packages/darkseid/archivers/__init__.py)</text><text class="terminal-884249335-r1" x="2147.2" y="337.2" textLength="12.2" clip-path="url(#terminal-884249335-line-13)">
+    <g class="terminal-1750544253-matrix">
+    <text class="terminal-1750544253-r2" x="976" y="20" textLength="12.2" clip-path="url(#terminal-1750544253-line-0)">
+</text><text class="terminal-1750544253-r3" x="12.2" y="44.4" textLength="85.4" clip-path="url(#terminal-1750544253-line-1)">Usage:&#160;</text><text class="terminal-1750544253-r1" x="97.6" y="44.4" textLength="414.8" clip-path="url(#terminal-1750544253-line-1)">Perdoo&#160;[OPTIONS]&#160;COMMAND&#160;[ARGS]...</text><text class="terminal-1750544253-r2" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-1750544253-line-1)">
+</text><text class="terminal-1750544253-r2" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-1750544253-line-2)">
+</text><text class="terminal-1750544253-r2" x="0" y="93.2" textLength="976" clip-path="url(#terminal-1750544253-line-3)">&#160;CLI&#160;tool&#160;for&#160;managing&#160;comic&#160;collections&#160;and&#160;settings.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1750544253-r2" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-1750544253-line-3)">
+</text><text class="terminal-1750544253-r2" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-1750544253-line-4)">
+</text><text class="terminal-1750544253-r2" x="976" y="142" textLength="12.2" clip-path="url(#terminal-1750544253-line-5)">
+</text><text class="terminal-1750544253-r4" x="0" y="166.4" textLength="24.4" clip-path="url(#terminal-1750544253-line-6)">╭─</text><text class="terminal-1750544253-r4" x="24.4" y="166.4" textLength="109.8" clip-path="url(#terminal-1750544253-line-6)">&#160;Options&#160;</text><text class="terminal-1750544253-r4" x="134.2" y="166.4" textLength="817.4" clip-path="url(#terminal-1750544253-line-6)">───────────────────────────────────────────────────────────────────</text><text class="terminal-1750544253-r4" x="951.6" y="166.4" textLength="24.4" clip-path="url(#terminal-1750544253-line-6)">─╮</text><text class="terminal-1750544253-r2" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-1750544253-line-6)">
+</text><text class="terminal-1750544253-r4" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-1750544253-line-7)">│</text><text class="terminal-1750544253-r5" x="24.4" y="190.8" textLength="12.2" clip-path="url(#terminal-1750544253-line-7)">-</text><text class="terminal-1750544253-r5" x="36.6" y="190.8" textLength="97.6" clip-path="url(#terminal-1750544253-line-7)">-version</text><text class="terminal-1750544253-r2" x="134.2" y="190.8" textLength="829.6" clip-path="url(#terminal-1750544253-line-7)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Show&#160;the&#160;version&#160;and&#160;exit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1750544253-r4" x="963.8" y="190.8" textLength="12.2" clip-path="url(#terminal-1750544253-line-7)">│</text><text class="terminal-1750544253-r2" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-1750544253-line-7)">
+</text><text class="terminal-1750544253-r4" x="0" y="215.2" textLength="12.2" clip-path="url(#terminal-1750544253-line-8)">│</text><text class="terminal-1750544253-r5" x="24.4" y="215.2" textLength="12.2" clip-path="url(#terminal-1750544253-line-8)">-</text><text class="terminal-1750544253-r5" x="36.6" y="215.2" textLength="97.6" clip-path="url(#terminal-1750544253-line-8)">-install</text><text class="terminal-1750544253-r5" x="134.2" y="215.2" textLength="134.2" clip-path="url(#terminal-1750544253-line-8)">-completion</text><text class="terminal-1750544253-r2" x="268.4" y="215.2" textLength="695.4" clip-path="url(#terminal-1750544253-line-8)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Install&#160;completion&#160;for&#160;the&#160;current&#160;shell.&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1750544253-r4" x="963.8" y="215.2" textLength="12.2" clip-path="url(#terminal-1750544253-line-8)">│</text><text class="terminal-1750544253-r2" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-1750544253-line-8)">
+</text><text class="terminal-1750544253-r4" x="0" y="239.6" textLength="12.2" clip-path="url(#terminal-1750544253-line-9)">│</text><text class="terminal-1750544253-r5" x="24.4" y="239.6" textLength="12.2" clip-path="url(#terminal-1750544253-line-9)">-</text><text class="terminal-1750544253-r5" x="36.6" y="239.6" textLength="61" clip-path="url(#terminal-1750544253-line-9)">-show</text><text class="terminal-1750544253-r5" x="97.6" y="239.6" textLength="134.2" clip-path="url(#terminal-1750544253-line-9)">-completion</text><text class="terminal-1750544253-r2" x="231.8" y="239.6" textLength="732" clip-path="url(#terminal-1750544253-line-9)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Show&#160;completion&#160;for&#160;the&#160;current&#160;shell,&#160;to&#160;copy&#160;</text><text class="terminal-1750544253-r4" x="963.8" y="239.6" textLength="12.2" clip-path="url(#terminal-1750544253-line-9)">│</text><text class="terminal-1750544253-r2" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-1750544253-line-9)">
+</text><text class="terminal-1750544253-r4" x="0" y="264" textLength="12.2" clip-path="url(#terminal-1750544253-line-10)">│</text><text class="terminal-1750544253-r2" x="12.2" y="264" textLength="951.6" clip-path="url(#terminal-1750544253-line-10)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;it&#160;or&#160;customize&#160;the&#160;installation.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1750544253-r4" x="963.8" y="264" textLength="12.2" clip-path="url(#terminal-1750544253-line-10)">│</text><text class="terminal-1750544253-r2" x="976" y="264" textLength="12.2" clip-path="url(#terminal-1750544253-line-10)">
+</text><text class="terminal-1750544253-r4" x="0" y="288.4" textLength="12.2" clip-path="url(#terminal-1750544253-line-11)">│</text><text class="terminal-1750544253-r5" x="24.4" y="288.4" textLength="12.2" clip-path="url(#terminal-1750544253-line-11)">-</text><text class="terminal-1750544253-r5" x="36.6" y="288.4" textLength="61" clip-path="url(#terminal-1750544253-line-11)">-help</text><text class="terminal-1750544253-r2" x="97.6" y="288.4" textLength="866.2" clip-path="url(#terminal-1750544253-line-11)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Show&#160;this&#160;message&#160;and&#160;exit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1750544253-r4" x="963.8" y="288.4" textLength="12.2" clip-path="url(#terminal-1750544253-line-11)">│</text><text class="terminal-1750544253-r2" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-1750544253-line-11)">
+</text><text class="terminal-1750544253-r4" x="0" y="312.8" textLength="976" clip-path="url(#terminal-1750544253-line-12)">╰──────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-1750544253-r2" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-1750544253-line-12)">
+</text><text class="terminal-1750544253-r4" x="0" y="337.2" textLength="24.4" clip-path="url(#terminal-1750544253-line-13)">╭─</text><text class="terminal-1750544253-r4" x="24.4" y="337.2" textLength="122" clip-path="url(#terminal-1750544253-line-13)">&#160;Commands&#160;</text><text class="terminal-1750544253-r4" x="146.4" y="337.2" textLength="805.2" clip-path="url(#terminal-1750544253-line-13)">──────────────────────────────────────────────────────────────────</text><text class="terminal-1750544253-r4" x="951.6" y="337.2" textLength="24.4" clip-path="url(#terminal-1750544253-line-13)">─╮</text><text class="terminal-1750544253-r2" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-1750544253-line-13)">
+</text><text class="terminal-1750544253-r4" x="0" y="361.6" textLength="12.2" clip-path="url(#terminal-1750544253-line-14)">│</text><text class="terminal-1750544253-r5" x="24.4" y="361.6" textLength="109.8" clip-path="url(#terminal-1750544253-line-14)">import&#160;&#160;&#160;</text><text class="terminal-1750544253-r2" x="146.4" y="361.6" textLength="817.4" clip-path="url(#terminal-1750544253-line-14)">&#160;Import&#160;comics&#160;into&#160;your&#160;collection&#160;using&#160;Perdoo.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1750544253-r4" x="963.8" y="361.6" textLength="12.2" clip-path="url(#terminal-1750544253-line-14)">│</text><text class="terminal-1750544253-r2" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-1750544253-line-14)">
+</text><text class="terminal-1750544253-r4" x="0" y="386" textLength="12.2" clip-path="url(#terminal-1750544253-line-15)">│</text><text class="terminal-1750544253-r5" x="24.4" y="386" textLength="109.8" clip-path="url(#terminal-1750544253-line-15)">archive&#160;&#160;</text><text class="terminal-1750544253-r2" x="146.4" y="386" textLength="817.4" clip-path="url(#terminal-1750544253-line-15)">&#160;Commands&#160;for&#160;inspecting&#160;and&#160;managing&#160;comic&#160;archive&#160;metadata.&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1750544253-r4" x="963.8" y="386" textLength="12.2" clip-path="url(#terminal-1750544253-line-15)">│</text><text class="terminal-1750544253-r2" x="976" y="386" textLength="12.2" clip-path="url(#terminal-1750544253-line-15)">
+</text><text class="terminal-1750544253-r4" x="0" y="410.4" textLength="12.2" clip-path="url(#terminal-1750544253-line-16)">│</text><text class="terminal-1750544253-r5" x="24.4" y="410.4" textLength="109.8" clip-path="url(#terminal-1750544253-line-16)">settings&#160;</text><text class="terminal-1750544253-r2" x="146.4" y="410.4" textLength="817.4" clip-path="url(#terminal-1750544253-line-16)">&#160;Commands&#160;for&#160;managing&#160;and&#160;configuring&#160;application&#160;settings.&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1750544253-r4" x="963.8" y="410.4" textLength="12.2" clip-path="url(#terminal-1750544253-line-16)">│</text><text class="terminal-1750544253-r2" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-1750544253-line-16)">
+</text><text class="terminal-1750544253-r4" x="0" y="434.8" textLength="976" clip-path="url(#terminal-1750544253-line-17)">╰──────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-1750544253-r2" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-1750544253-line-17)">
+</text><text class="terminal-1750544253-r2" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-1750544253-line-18)">
 </text>
     </g>
     </g>

--- a/docs/img/perdoo-import.svg
+++ b/docs/img/perdoo-import.svg
@@ -1,4 +1,4 @@
-<svg class="rich-terminal" viewBox="0 0 2166 391.59999999999997" xmlns="http://www.w3.org/2000/svg">
+<svg class="rich-terminal" viewBox="0 0 994 806.4" xmlns="http://www.w3.org/2000/svg">
     <!-- Generated with Rich https://www.textualize.io -->
     <style>
 
@@ -19,91 +19,167 @@
         font-weight: 700;
     }
 
-    .terminal-884249335-matrix {
+    .terminal-4103779917-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-884249335-title {
+    .terminal-4103779917-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-884249335-r1 { fill: #c5c8c6 }
+    .terminal-4103779917-r1 { fill: #c5c8c6;font-weight: bold }
+.terminal-4103779917-r2 { fill: #c5c8c6 }
+.terminal-4103779917-r3 { fill: #d0b344;font-weight: bold }
+.terminal-4103779917-r4 { fill: #868887 }
+.terminal-4103779917-r5 { fill: #cc555a }
+.terminal-4103779917-r6 { fill: #8a4346 }
+.terminal-4103779917-r7 { fill: #68a0b3;font-weight: bold }
+.terminal-4103779917-r8 { fill: #98a84b;font-weight: bold }
+.terminal-4103779917-r9 { fill: #8d7b39;font-weight: bold }
     </style>
 
     <defs>
-    <clipPath id="terminal-884249335-clip-terminal">
-      <rect x="0" y="0" width="2146.2" height="340.59999999999997" />
+    <clipPath id="terminal-4103779917-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="755.4" />
     </clipPath>
-    <clipPath id="terminal-884249335-line-0">
-    <rect x="0" y="1.5" width="2147.2" height="24.65"/>
+    <clipPath id="terminal-4103779917-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-1">
-    <rect x="0" y="25.9" width="2147.2" height="24.65"/>
+<clipPath id="terminal-4103779917-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-2">
-    <rect x="0" y="50.3" width="2147.2" height="24.65"/>
+<clipPath id="terminal-4103779917-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-3">
-    <rect x="0" y="74.7" width="2147.2" height="24.65"/>
+<clipPath id="terminal-4103779917-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-4">
-    <rect x="0" y="99.1" width="2147.2" height="24.65"/>
+<clipPath id="terminal-4103779917-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-5">
-    <rect x="0" y="123.5" width="2147.2" height="24.65"/>
+<clipPath id="terminal-4103779917-line-5">
+    <rect x="0" y="123.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-6">
-    <rect x="0" y="147.9" width="2147.2" height="24.65"/>
+<clipPath id="terminal-4103779917-line-6">
+    <rect x="0" y="147.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-7">
-    <rect x="0" y="172.3" width="2147.2" height="24.65"/>
+<clipPath id="terminal-4103779917-line-7">
+    <rect x="0" y="172.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-8">
-    <rect x="0" y="196.7" width="2147.2" height="24.65"/>
+<clipPath id="terminal-4103779917-line-8">
+    <rect x="0" y="196.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-9">
-    <rect x="0" y="221.1" width="2147.2" height="24.65"/>
+<clipPath id="terminal-4103779917-line-9">
+    <rect x="0" y="221.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-10">
-    <rect x="0" y="245.5" width="2147.2" height="24.65"/>
+<clipPath id="terminal-4103779917-line-10">
+    <rect x="0" y="245.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-11">
-    <rect x="0" y="269.9" width="2147.2" height="24.65"/>
+<clipPath id="terminal-4103779917-line-11">
+    <rect x="0" y="269.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-12">
-    <rect x="0" y="294.3" width="2147.2" height="24.65"/>
+<clipPath id="terminal-4103779917-line-12">
+    <rect x="0" y="294.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4103779917-line-13">
+    <rect x="0" y="318.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4103779917-line-14">
+    <rect x="0" y="343.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4103779917-line-15">
+    <rect x="0" y="367.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4103779917-line-16">
+    <rect x="0" y="391.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4103779917-line-17">
+    <rect x="0" y="416.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4103779917-line-18">
+    <rect x="0" y="440.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4103779917-line-19">
+    <rect x="0" y="465.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4103779917-line-20">
+    <rect x="0" y="489.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4103779917-line-21">
+    <rect x="0" y="513.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4103779917-line-22">
+    <rect x="0" y="538.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4103779917-line-23">
+    <rect x="0" y="562.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4103779917-line-24">
+    <rect x="0" y="587.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4103779917-line-25">
+    <rect x="0" y="611.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4103779917-line-26">
+    <rect x="0" y="635.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4103779917-line-27">
+    <rect x="0" y="660.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4103779917-line-28">
+    <rect x="0" y="684.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4103779917-line-29">
+    <rect x="0" y="709.1" width="976" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="2164" height="389.6" rx="8"/>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="804.4" rx="8"/>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-884249335-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-4103779917-clip-terminal)">
     
-    <g class="terminal-884249335-matrix">
-    <text class="terminal-884249335-r1" x="0" y="20" textLength="414.8" clip-path="url(#terminal-884249335-line-0)">Traceback&#160;(most&#160;recent&#160;call&#160;last):</text><text class="terminal-884249335-r1" x="2147.2" y="20" textLength="12.2" clip-path="url(#terminal-884249335-line-0)">
-</text><text class="terminal-884249335-r1" x="0" y="44.4" textLength="951.6" clip-path="url(#terminal-884249335-line-1)">&#160;&#160;File&#160;&quot;/home/runner/work/Perdoo/Perdoo/.venv/bin/Perdoo&quot;,&#160;line&#160;4,&#160;in&#160;&lt;module&gt;</text><text class="terminal-884249335-r1" x="2147.2" y="44.4" textLength="12.2" clip-path="url(#terminal-884249335-line-1)">
-</text><text class="terminal-884249335-r1" x="0" y="68.8" textLength="427" clip-path="url(#terminal-884249335-line-2)">&#160;&#160;&#160;&#160;from&#160;perdoo.__main__&#160;import&#160;app</text><text class="terminal-884249335-r1" x="2147.2" y="68.8" textLength="12.2" clip-path="url(#terminal-884249335-line-2)">
-</text><text class="terminal-884249335-r1" x="0" y="93.2" textLength="988.2" clip-path="url(#terminal-884249335-line-3)">&#160;&#160;File&#160;&quot;/home/runner/work/Perdoo/Perdoo/perdoo/__main__.py&quot;,&#160;line&#160;12,&#160;in&#160;&lt;module&gt;</text><text class="terminal-884249335-r1" x="2147.2" y="93.2" textLength="12.2" clip-path="url(#terminal-884249335-line-3)">
-</text><text class="terminal-884249335-r1" x="0" y="117.6" textLength="634.4" clip-path="url(#terminal-884249335-line-4)">&#160;&#160;&#160;&#160;from&#160;perdoo.cli&#160;import&#160;archive_app,&#160;settings_app</text><text class="terminal-884249335-r1" x="2147.2" y="117.6" textLength="12.2" clip-path="url(#terminal-884249335-line-4)">
-</text><text class="terminal-884249335-r1" x="0" y="142" textLength="1024.8" clip-path="url(#terminal-884249335-line-5)">&#160;&#160;File&#160;&quot;/home/runner/work/Perdoo/Perdoo/perdoo/cli/__init__.py&quot;,&#160;line&#160;3,&#160;in&#160;&lt;module&gt;</text><text class="terminal-884249335-r1" x="2147.2" y="142" textLength="12.2" clip-path="url(#terminal-884249335-line-5)">
-</text><text class="terminal-884249335-r1" x="0" y="166.4" textLength="646.6" clip-path="url(#terminal-884249335-line-6)">&#160;&#160;&#160;&#160;from&#160;perdoo.cli.archive&#160;import&#160;app&#160;as&#160;archive_app</text><text class="terminal-884249335-r1" x="2147.2" y="166.4" textLength="12.2" clip-path="url(#terminal-884249335-line-6)">
-</text><text class="terminal-884249335-r1" x="0" y="190.8" textLength="1012.6" clip-path="url(#terminal-884249335-line-7)">&#160;&#160;File&#160;&quot;/home/runner/work/Perdoo/Perdoo/perdoo/cli/archive.py&quot;,&#160;line&#160;8,&#160;in&#160;&lt;module&gt;</text><text class="terminal-884249335-r1" x="2147.2" y="190.8" textLength="12.2" clip-path="url(#terminal-884249335-line-7)">
-</text><text class="terminal-884249335-r1" x="0" y="215.2" textLength="414.8" clip-path="url(#terminal-884249335-line-8)">&#160;&#160;&#160;&#160;from&#160;perdoo.comic&#160;import&#160;Comic</text><text class="terminal-884249335-r1" x="2147.2" y="215.2" textLength="12.2" clip-path="url(#terminal-884249335-line-8)">
-</text><text class="terminal-884249335-r1" x="0" y="239.6" textLength="951.6" clip-path="url(#terminal-884249335-line-9)">&#160;&#160;File&#160;&quot;/home/runner/work/Perdoo/Perdoo/perdoo/comic.py&quot;,&#160;line&#160;14,&#160;in&#160;&lt;module&gt;</text><text class="terminal-884249335-r1" x="2147.2" y="239.6" textLength="12.2" clip-path="url(#terminal-884249335-line-9)">
-</text><text class="terminal-884249335-r1" x="0" y="264" textLength="439.2" clip-path="url(#terminal-884249335-line-10)">&#160;&#160;&#160;&#160;from&#160;darkseid.archivers&#160;import&#160;(</text><text class="terminal-884249335-r1" x="2147.2" y="264" textLength="12.2" clip-path="url(#terminal-884249335-line-10)">
-</text><text class="terminal-884249335-r1" x="0" y="288.4" textLength="231.8" clip-path="url(#terminal-884249335-line-11)">&#160;&#160;&#160;&#160;...&lt;6&#160;lines&gt;...</text><text class="terminal-884249335-r1" x="2147.2" y="288.4" textLength="12.2" clip-path="url(#terminal-884249335-line-11)">
-</text><text class="terminal-884249335-r1" x="0" y="312.8" textLength="61" clip-path="url(#terminal-884249335-line-12)">&#160;&#160;&#160;&#160;)</text><text class="terminal-884249335-r1" x="2147.2" y="312.8" textLength="12.2" clip-path="url(#terminal-884249335-line-12)">
-</text><text class="terminal-884249335-r1" x="0" y="337.2" textLength="2147.2" clip-path="url(#terminal-884249335-line-13)">ImportError:&#160;cannot&#160;import&#160;name&#160;&#x27;SevenZipArchiver&#x27;&#160;from&#160;&#x27;darkseid.archivers&#x27;&#160;(/home/runner/work/Perdoo/Perdoo/.venv/lib/python3.13/site-packages/darkseid/archivers/__init__.py)</text><text class="terminal-884249335-r1" x="2147.2" y="337.2" textLength="12.2" clip-path="url(#terminal-884249335-line-13)">
+    <g class="terminal-4103779917-matrix">
+    <text class="terminal-4103779917-r2" x="976" y="20" textLength="12.2" clip-path="url(#terminal-4103779917-line-0)">
+</text><text class="terminal-4103779917-r3" x="12.2" y="44.4" textLength="85.4" clip-path="url(#terminal-4103779917-line-1)">Usage:&#160;</text><text class="terminal-4103779917-r1" x="97.6" y="44.4" textLength="366" clip-path="url(#terminal-4103779917-line-1)">Perdoo&#160;import&#160;[OPTIONS]&#160;TARGET</text><text class="terminal-4103779917-r2" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-4103779917-line-1)">
+</text><text class="terminal-4103779917-r2" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-4103779917-line-2)">
+</text><text class="terminal-4103779917-r2" x="0" y="93.2" textLength="976" clip-path="url(#terminal-4103779917-line-3)">&#160;Import&#160;comics&#160;into&#160;your&#160;collection&#160;using&#160;Perdoo.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-4103779917-r2" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-4103779917-line-3)">
+</text><text class="terminal-4103779917-r2" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-4103779917-line-4)">
+</text><text class="terminal-4103779917-r2" x="976" y="142" textLength="12.2" clip-path="url(#terminal-4103779917-line-5)">
+</text><text class="terminal-4103779917-r4" x="0" y="166.4" textLength="24.4" clip-path="url(#terminal-4103779917-line-6)">╭─</text><text class="terminal-4103779917-r4" x="24.4" y="166.4" textLength="134.2" clip-path="url(#terminal-4103779917-line-6)">&#160;Arguments&#160;</text><text class="terminal-4103779917-r4" x="158.6" y="166.4" textLength="793" clip-path="url(#terminal-4103779917-line-6)">─────────────────────────────────────────────────────────────────</text><text class="terminal-4103779917-r4" x="951.6" y="166.4" textLength="24.4" clip-path="url(#terminal-4103779917-line-6)">─╮</text><text class="terminal-4103779917-r2" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-4103779917-line-6)">
+</text><text class="terminal-4103779917-r4" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-4103779917-line-7)">│</text><text class="terminal-4103779917-r5" x="24.4" y="190.8" textLength="12.2" clip-path="url(#terminal-4103779917-line-7)">*</text><text class="terminal-4103779917-r2" x="36.6" y="190.8" textLength="195.2" clip-path="url(#terminal-4103779917-line-7)">&#160;&#160;&#160;&#160;target&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-4103779917-r3" x="231.8" y="190.8" textLength="48.8" clip-path="url(#terminal-4103779917-line-7)">PATH</text><text class="terminal-4103779917-r2" x="280.6" y="190.8" textLength="683.2" clip-path="url(#terminal-4103779917-line-7)">&#160;&#160;Import&#160;comics&#160;from&#160;the&#160;specified&#160;file/folder.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-4103779917-r4" x="963.8" y="190.8" textLength="12.2" clip-path="url(#terminal-4103779917-line-7)">│</text><text class="terminal-4103779917-r2" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-4103779917-line-7)">
+</text><text class="terminal-4103779917-r4" x="0" y="215.2" textLength="12.2" clip-path="url(#terminal-4103779917-line-8)">│</text><text class="terminal-4103779917-r6" x="305" y="215.2" textLength="549" clip-path="url(#terminal-4103779917-line-8)">[required]&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-4103779917-r4" x="963.8" y="215.2" textLength="12.2" clip-path="url(#terminal-4103779917-line-8)">│</text><text class="terminal-4103779917-r2" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-4103779917-line-8)">
+</text><text class="terminal-4103779917-r4" x="0" y="239.6" textLength="976" clip-path="url(#terminal-4103779917-line-9)">╰──────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-4103779917-r2" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-4103779917-line-9)">
+</text><text class="terminal-4103779917-r4" x="0" y="264" textLength="24.4" clip-path="url(#terminal-4103779917-line-10)">╭─</text><text class="terminal-4103779917-r4" x="24.4" y="264" textLength="109.8" clip-path="url(#terminal-4103779917-line-10)">&#160;Options&#160;</text><text class="terminal-4103779917-r4" x="134.2" y="264" textLength="817.4" clip-path="url(#terminal-4103779917-line-10)">───────────────────────────────────────────────────────────────────</text><text class="terminal-4103779917-r4" x="951.6" y="264" textLength="24.4" clip-path="url(#terminal-4103779917-line-10)">─╮</text><text class="terminal-4103779917-r2" x="976" y="264" textLength="12.2" clip-path="url(#terminal-4103779917-line-10)">
+</text><text class="terminal-4103779917-r4" x="0" y="288.4" textLength="12.2" clip-path="url(#terminal-4103779917-line-11)">│</text><text class="terminal-4103779917-r7" x="24.4" y="288.4" textLength="12.2" clip-path="url(#terminal-4103779917-line-11)">-</text><text class="terminal-4103779917-r7" x="36.6" y="288.4" textLength="61" clip-path="url(#terminal-4103779917-line-11)">-skip</text><text class="terminal-4103779917-r7" x="97.6" y="288.4" textLength="97.6" clip-path="url(#terminal-4103779917-line-11)">-convert</text><text class="terminal-4103779917-r2" x="573.4" y="288.4" textLength="390.4" clip-path="url(#terminal-4103779917-line-11)">&#160;&#160;Skip&#160;converting&#160;comics&#160;to&#160;the&#160;</text><text class="terminal-4103779917-r4" x="963.8" y="288.4" textLength="12.2" clip-path="url(#terminal-4103779917-line-11)">│</text><text class="terminal-4103779917-r2" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-4103779917-line-11)">
+</text><text class="terminal-4103779917-r4" x="0" y="312.8" textLength="12.2" clip-path="url(#terminal-4103779917-line-12)">│</text><text class="terminal-4103779917-r2" x="12.2" y="312.8" textLength="951.6" clip-path="url(#terminal-4103779917-line-12)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;configured&#160;format.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-4103779917-r4" x="963.8" y="312.8" textLength="12.2" clip-path="url(#terminal-4103779917-line-12)">│</text><text class="terminal-4103779917-r2" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-4103779917-line-12)">
+</text><text class="terminal-4103779917-r4" x="0" y="337.2" textLength="12.2" clip-path="url(#terminal-4103779917-line-13)">│</text><text class="terminal-4103779917-r7" x="24.4" y="337.2" textLength="12.2" clip-path="url(#terminal-4103779917-line-13)">-</text><text class="terminal-4103779917-r7" x="36.6" y="337.2" textLength="61" clip-path="url(#terminal-4103779917-line-13)">-sync</text><text class="terminal-4103779917-r8" x="219.6" y="337.2" textLength="24.4" clip-path="url(#terminal-4103779917-line-13)">-s</text><text class="terminal-4103779917-r9" x="317.2" y="337.2" textLength="12.2" clip-path="url(#terminal-4103779917-line-13)">[</text><text class="terminal-4103779917-r3" x="329.4" y="337.2" textLength="61" clip-path="url(#terminal-4103779917-line-13)">force</text><text class="terminal-4103779917-r9" x="390.4" y="337.2" textLength="12.2" clip-path="url(#terminal-4103779917-line-13)">|</text><text class="terminal-4103779917-r3" x="402.6" y="337.2" textLength="97.6" clip-path="url(#terminal-4103779917-line-13)">outdated</text><text class="terminal-4103779917-r9" x="500.2" y="337.2" textLength="12.2" clip-path="url(#terminal-4103779917-line-13)">|</text><text class="terminal-4103779917-r3" x="512.4" y="337.2" textLength="48.8" clip-path="url(#terminal-4103779917-line-13)">skip</text><text class="terminal-4103779917-r9" x="561.2" y="337.2" textLength="12.2" clip-path="url(#terminal-4103779917-line-13)">]</text><text class="terminal-4103779917-r2" x="573.4" y="337.2" textLength="390.4" clip-path="url(#terminal-4103779917-line-13)">&#160;&#160;Sync&#160;ComicInfo/MetronInfo&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-4103779917-r4" x="963.8" y="337.2" textLength="12.2" clip-path="url(#terminal-4103779917-line-13)">│</text><text class="terminal-4103779917-r2" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-4103779917-line-13)">
+</text><text class="terminal-4103779917-r4" x="0" y="361.6" textLength="12.2" clip-path="url(#terminal-4103779917-line-14)">│</text><text class="terminal-4103779917-r2" x="12.2" y="361.6" textLength="951.6" clip-path="url(#terminal-4103779917-line-14)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;with&#160;online&#160;services.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-4103779917-r4" x="963.8" y="361.6" textLength="12.2" clip-path="url(#terminal-4103779917-line-14)">│</text><text class="terminal-4103779917-r2" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-4103779917-line-14)">
+</text><text class="terminal-4103779917-r4" x="0" y="386" textLength="12.2" clip-path="url(#terminal-4103779917-line-15)">│</text><text class="terminal-4103779917-r4" x="597.8" y="386" textLength="353.8" clip-path="url(#terminal-4103779917-line-15)">[default:&#160;Outdated]&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-4103779917-r4" x="963.8" y="386" textLength="12.2" clip-path="url(#terminal-4103779917-line-15)">│</text><text class="terminal-4103779917-r2" x="976" y="386" textLength="12.2" clip-path="url(#terminal-4103779917-line-15)">
+</text><text class="terminal-4103779917-r4" x="0" y="410.4" textLength="12.2" clip-path="url(#terminal-4103779917-line-16)">│</text><text class="terminal-4103779917-r7" x="24.4" y="410.4" textLength="12.2" clip-path="url(#terminal-4103779917-line-16)">-</text><text class="terminal-4103779917-r7" x="36.6" y="410.4" textLength="61" clip-path="url(#terminal-4103779917-line-16)">-skip</text><text class="terminal-4103779917-r7" x="97.6" y="410.4" textLength="73.2" clip-path="url(#terminal-4103779917-line-16)">-clean</text><text class="terminal-4103779917-r2" x="573.4" y="410.4" textLength="390.4" clip-path="url(#terminal-4103779917-line-16)">&#160;&#160;Skip&#160;removing&#160;any&#160;files&#160;not&#160;&#160;&#160;</text><text class="terminal-4103779917-r4" x="963.8" y="410.4" textLength="12.2" clip-path="url(#terminal-4103779917-line-16)">│</text><text class="terminal-4103779917-r2" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-4103779917-line-16)">
+</text><text class="terminal-4103779917-r4" x="0" y="434.8" textLength="12.2" clip-path="url(#terminal-4103779917-line-17)">│</text><text class="terminal-4103779917-r2" x="12.2" y="434.8" textLength="951.6" clip-path="url(#terminal-4103779917-line-17)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;listed&#160;in&#160;the&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-4103779917-r4" x="963.8" y="434.8" textLength="12.2" clip-path="url(#terminal-4103779917-line-17)">│</text><text class="terminal-4103779917-r2" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-4103779917-line-17)">
+</text><text class="terminal-4103779917-r4" x="0" y="459.2" textLength="12.2" clip-path="url(#terminal-4103779917-line-18)">│</text><text class="terminal-4103779917-r2" x="12.2" y="459.2" textLength="951.6" clip-path="url(#terminal-4103779917-line-18)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#x27;image_extensions&#x27;&#160;setting.&#160;&#160;&#160;</text><text class="terminal-4103779917-r4" x="963.8" y="459.2" textLength="12.2" clip-path="url(#terminal-4103779917-line-18)">│</text><text class="terminal-4103779917-r2" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-4103779917-line-18)">
+</text><text class="terminal-4103779917-r4" x="0" y="483.6" textLength="12.2" clip-path="url(#terminal-4103779917-line-19)">│</text><text class="terminal-4103779917-r7" x="24.4" y="483.6" textLength="12.2" clip-path="url(#terminal-4103779917-line-19)">-</text><text class="terminal-4103779917-r7" x="36.6" y="483.6" textLength="61" clip-path="url(#terminal-4103779917-line-19)">-skip</text><text class="terminal-4103779917-r7" x="97.6" y="483.6" textLength="85.4" clip-path="url(#terminal-4103779917-line-19)">-rename</text><text class="terminal-4103779917-r2" x="573.4" y="483.6" textLength="390.4" clip-path="url(#terminal-4103779917-line-19)">&#160;&#160;Skip&#160;organizing&#160;and&#160;renaming&#160;&#160;</text><text class="terminal-4103779917-r4" x="963.8" y="483.6" textLength="12.2" clip-path="url(#terminal-4103779917-line-19)">│</text><text class="terminal-4103779917-r2" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-4103779917-line-19)">
+</text><text class="terminal-4103779917-r4" x="0" y="508" textLength="12.2" clip-path="url(#terminal-4103779917-line-20)">│</text><text class="terminal-4103779917-r2" x="12.2" y="508" textLength="951.6" clip-path="url(#terminal-4103779917-line-20)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;comics&#160;based&#160;on&#160;their&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-4103779917-r4" x="963.8" y="508" textLength="12.2" clip-path="url(#terminal-4103779917-line-20)">│</text><text class="terminal-4103779917-r2" x="976" y="508" textLength="12.2" clip-path="url(#terminal-4103779917-line-20)">
+</text><text class="terminal-4103779917-r4" x="0" y="532.4" textLength="12.2" clip-path="url(#terminal-4103779917-line-21)">│</text><text class="terminal-4103779917-r2" x="12.2" y="532.4" textLength="951.6" clip-path="url(#terminal-4103779917-line-21)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;MetronInfo/ComicInfo.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-4103779917-r4" x="963.8" y="532.4" textLength="12.2" clip-path="url(#terminal-4103779917-line-21)">│</text><text class="terminal-4103779917-r2" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-4103779917-line-21)">
+</text><text class="terminal-4103779917-r4" x="0" y="556.8" textLength="12.2" clip-path="url(#terminal-4103779917-line-22)">│</text><text class="terminal-4103779917-r7" x="24.4" y="556.8" textLength="12.2" clip-path="url(#terminal-4103779917-line-22)">-</text><text class="terminal-4103779917-r7" x="36.6" y="556.8" textLength="73.2" clip-path="url(#terminal-4103779917-line-22)">-clean</text><text class="terminal-4103779917-r8" x="219.6" y="556.8" textLength="24.4" clip-path="url(#terminal-4103779917-line-22)">-c</text><text class="terminal-4103779917-r2" x="573.4" y="556.8" textLength="390.4" clip-path="url(#terminal-4103779917-line-22)">&#160;&#160;Clean&#160;the&#160;cache&#160;before&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-4103779917-r4" x="963.8" y="556.8" textLength="12.2" clip-path="url(#terminal-4103779917-line-22)">│</text><text class="terminal-4103779917-r2" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-4103779917-line-22)">
+</text><text class="terminal-4103779917-r4" x="0" y="581.2" textLength="12.2" clip-path="url(#terminal-4103779917-line-23)">│</text><text class="terminal-4103779917-r2" x="12.2" y="581.2" textLength="951.6" clip-path="url(#terminal-4103779917-line-23)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;starting&#160;the&#160;synchronization&#160;&#160;</text><text class="terminal-4103779917-r4" x="963.8" y="581.2" textLength="12.2" clip-path="url(#terminal-4103779917-line-23)">│</text><text class="terminal-4103779917-r2" x="976" y="581.2" textLength="12.2" clip-path="url(#terminal-4103779917-line-23)">
+</text><text class="terminal-4103779917-r4" x="0" y="605.6" textLength="12.2" clip-path="url(#terminal-4103779917-line-24)">│</text><text class="terminal-4103779917-r2" x="12.2" y="605.6" textLength="951.6" clip-path="url(#terminal-4103779917-line-24)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;process.&#160;Removes&#160;all&#160;cached&#160;&#160;&#160;</text><text class="terminal-4103779917-r4" x="963.8" y="605.6" textLength="12.2" clip-path="url(#terminal-4103779917-line-24)">│</text><text class="terminal-4103779917-r2" x="976" y="605.6" textLength="12.2" clip-path="url(#terminal-4103779917-line-24)">
+</text><text class="terminal-4103779917-r4" x="0" y="630" textLength="12.2" clip-path="url(#terminal-4103779917-line-25)">│</text><text class="terminal-4103779917-r2" x="12.2" y="630" textLength="951.6" clip-path="url(#terminal-4103779917-line-25)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;files.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-4103779917-r4" x="963.8" y="630" textLength="12.2" clip-path="url(#terminal-4103779917-line-25)">│</text><text class="terminal-4103779917-r2" x="976" y="630" textLength="12.2" clip-path="url(#terminal-4103779917-line-25)">
+</text><text class="terminal-4103779917-r4" x="0" y="654.4" textLength="12.2" clip-path="url(#terminal-4103779917-line-26)">│</text><text class="terminal-4103779917-r7" x="24.4" y="654.4" textLength="12.2" clip-path="url(#terminal-4103779917-line-26)">-</text><text class="terminal-4103779917-r7" x="36.6" y="654.4" textLength="73.2" clip-path="url(#terminal-4103779917-line-26)">-debug</text><text class="terminal-4103779917-r2" x="573.4" y="654.4" textLength="390.4" clip-path="url(#terminal-4103779917-line-26)">&#160;&#160;Enable&#160;debug&#160;mode&#160;to&#160;show&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-4103779917-r4" x="963.8" y="654.4" textLength="12.2" clip-path="url(#terminal-4103779917-line-26)">│</text><text class="terminal-4103779917-r2" x="976" y="654.4" textLength="12.2" clip-path="url(#terminal-4103779917-line-26)">
+</text><text class="terminal-4103779917-r4" x="0" y="678.8" textLength="12.2" clip-path="url(#terminal-4103779917-line-27)">│</text><text class="terminal-4103779917-r2" x="12.2" y="678.8" textLength="951.6" clip-path="url(#terminal-4103779917-line-27)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;extra&#160;information.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-4103779917-r4" x="963.8" y="678.8" textLength="12.2" clip-path="url(#terminal-4103779917-line-27)">│</text><text class="terminal-4103779917-r2" x="976" y="678.8" textLength="12.2" clip-path="url(#terminal-4103779917-line-27)">
+</text><text class="terminal-4103779917-r4" x="0" y="703.2" textLength="12.2" clip-path="url(#terminal-4103779917-line-28)">│</text><text class="terminal-4103779917-r7" x="24.4" y="703.2" textLength="12.2" clip-path="url(#terminal-4103779917-line-28)">-</text><text class="terminal-4103779917-r7" x="36.6" y="703.2" textLength="61" clip-path="url(#terminal-4103779917-line-28)">-help</text><text class="terminal-4103779917-r2" x="573.4" y="703.2" textLength="390.4" clip-path="url(#terminal-4103779917-line-28)">&#160;&#160;Show&#160;this&#160;message&#160;and&#160;exit.&#160;&#160;&#160;</text><text class="terminal-4103779917-r4" x="963.8" y="703.2" textLength="12.2" clip-path="url(#terminal-4103779917-line-28)">│</text><text class="terminal-4103779917-r2" x="976" y="703.2" textLength="12.2" clip-path="url(#terminal-4103779917-line-28)">
+</text><text class="terminal-4103779917-r4" x="0" y="727.6" textLength="976" clip-path="url(#terminal-4103779917-line-29)">╰──────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-4103779917-r2" x="976" y="727.6" textLength="12.2" clip-path="url(#terminal-4103779917-line-29)">
+</text><text class="terminal-4103779917-r2" x="976" y="752" textLength="12.2" clip-path="url(#terminal-4103779917-line-30)">
 </text>
     </g>
     </g>

--- a/docs/img/perdoo-settings-locate.svg
+++ b/docs/img/perdoo-settings-locate.svg
@@ -1,4 +1,4 @@
-<svg class="rich-terminal" viewBox="0 0 2166 391.59999999999997" xmlns="http://www.w3.org/2000/svg">
+<svg class="rich-terminal" viewBox="0 0 994 294.0" xmlns="http://www.w3.org/2000/svg">
     <!-- Generated with Rich https://www.textualize.io -->
     <style>
 
@@ -19,91 +19,79 @@
         font-weight: 700;
     }
 
-    .terminal-884249335-matrix {
+    .terminal-1679728644-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-884249335-title {
+    .terminal-1679728644-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-884249335-r1 { fill: #c5c8c6 }
+    .terminal-1679728644-r1 { fill: #c5c8c6;font-weight: bold }
+.terminal-1679728644-r2 { fill: #c5c8c6 }
+.terminal-1679728644-r3 { fill: #d0b344;font-weight: bold }
+.terminal-1679728644-r4 { fill: #868887 }
+.terminal-1679728644-r5 { fill: #68a0b3;font-weight: bold }
     </style>
 
     <defs>
-    <clipPath id="terminal-884249335-clip-terminal">
-      <rect x="0" y="0" width="2146.2" height="340.59999999999997" />
+    <clipPath id="terminal-1679728644-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="243.0" />
     </clipPath>
-    <clipPath id="terminal-884249335-line-0">
-    <rect x="0" y="1.5" width="2147.2" height="24.65"/>
+    <clipPath id="terminal-1679728644-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-1">
-    <rect x="0" y="25.9" width="2147.2" height="24.65"/>
+<clipPath id="terminal-1679728644-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-2">
-    <rect x="0" y="50.3" width="2147.2" height="24.65"/>
+<clipPath id="terminal-1679728644-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-3">
-    <rect x="0" y="74.7" width="2147.2" height="24.65"/>
+<clipPath id="terminal-1679728644-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-4">
-    <rect x="0" y="99.1" width="2147.2" height="24.65"/>
+<clipPath id="terminal-1679728644-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-5">
-    <rect x="0" y="123.5" width="2147.2" height="24.65"/>
+<clipPath id="terminal-1679728644-line-5">
+    <rect x="0" y="123.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-6">
-    <rect x="0" y="147.9" width="2147.2" height="24.65"/>
+<clipPath id="terminal-1679728644-line-6">
+    <rect x="0" y="147.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-7">
-    <rect x="0" y="172.3" width="2147.2" height="24.65"/>
+<clipPath id="terminal-1679728644-line-7">
+    <rect x="0" y="172.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-8">
-    <rect x="0" y="196.7" width="2147.2" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-884249335-line-9">
-    <rect x="0" y="221.1" width="2147.2" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-884249335-line-10">
-    <rect x="0" y="245.5" width="2147.2" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-884249335-line-11">
-    <rect x="0" y="269.9" width="2147.2" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-884249335-line-12">
-    <rect x="0" y="294.3" width="2147.2" height="24.65"/>
+<clipPath id="terminal-1679728644-line-8">
+    <rect x="0" y="196.7" width="976" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="2164" height="389.6" rx="8"/>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="292" rx="8"/>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-884249335-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-1679728644-clip-terminal)">
     
-    <g class="terminal-884249335-matrix">
-    <text class="terminal-884249335-r1" x="0" y="20" textLength="414.8" clip-path="url(#terminal-884249335-line-0)">Traceback&#160;(most&#160;recent&#160;call&#160;last):</text><text class="terminal-884249335-r1" x="2147.2" y="20" textLength="12.2" clip-path="url(#terminal-884249335-line-0)">
-</text><text class="terminal-884249335-r1" x="0" y="44.4" textLength="951.6" clip-path="url(#terminal-884249335-line-1)">&#160;&#160;File&#160;&quot;/home/runner/work/Perdoo/Perdoo/.venv/bin/Perdoo&quot;,&#160;line&#160;4,&#160;in&#160;&lt;module&gt;</text><text class="terminal-884249335-r1" x="2147.2" y="44.4" textLength="12.2" clip-path="url(#terminal-884249335-line-1)">
-</text><text class="terminal-884249335-r1" x="0" y="68.8" textLength="427" clip-path="url(#terminal-884249335-line-2)">&#160;&#160;&#160;&#160;from&#160;perdoo.__main__&#160;import&#160;app</text><text class="terminal-884249335-r1" x="2147.2" y="68.8" textLength="12.2" clip-path="url(#terminal-884249335-line-2)">
-</text><text class="terminal-884249335-r1" x="0" y="93.2" textLength="988.2" clip-path="url(#terminal-884249335-line-3)">&#160;&#160;File&#160;&quot;/home/runner/work/Perdoo/Perdoo/perdoo/__main__.py&quot;,&#160;line&#160;12,&#160;in&#160;&lt;module&gt;</text><text class="terminal-884249335-r1" x="2147.2" y="93.2" textLength="12.2" clip-path="url(#terminal-884249335-line-3)">
-</text><text class="terminal-884249335-r1" x="0" y="117.6" textLength="634.4" clip-path="url(#terminal-884249335-line-4)">&#160;&#160;&#160;&#160;from&#160;perdoo.cli&#160;import&#160;archive_app,&#160;settings_app</text><text class="terminal-884249335-r1" x="2147.2" y="117.6" textLength="12.2" clip-path="url(#terminal-884249335-line-4)">
-</text><text class="terminal-884249335-r1" x="0" y="142" textLength="1024.8" clip-path="url(#terminal-884249335-line-5)">&#160;&#160;File&#160;&quot;/home/runner/work/Perdoo/Perdoo/perdoo/cli/__init__.py&quot;,&#160;line&#160;3,&#160;in&#160;&lt;module&gt;</text><text class="terminal-884249335-r1" x="2147.2" y="142" textLength="12.2" clip-path="url(#terminal-884249335-line-5)">
-</text><text class="terminal-884249335-r1" x="0" y="166.4" textLength="646.6" clip-path="url(#terminal-884249335-line-6)">&#160;&#160;&#160;&#160;from&#160;perdoo.cli.archive&#160;import&#160;app&#160;as&#160;archive_app</text><text class="terminal-884249335-r1" x="2147.2" y="166.4" textLength="12.2" clip-path="url(#terminal-884249335-line-6)">
-</text><text class="terminal-884249335-r1" x="0" y="190.8" textLength="1012.6" clip-path="url(#terminal-884249335-line-7)">&#160;&#160;File&#160;&quot;/home/runner/work/Perdoo/Perdoo/perdoo/cli/archive.py&quot;,&#160;line&#160;8,&#160;in&#160;&lt;module&gt;</text><text class="terminal-884249335-r1" x="2147.2" y="190.8" textLength="12.2" clip-path="url(#terminal-884249335-line-7)">
-</text><text class="terminal-884249335-r1" x="0" y="215.2" textLength="414.8" clip-path="url(#terminal-884249335-line-8)">&#160;&#160;&#160;&#160;from&#160;perdoo.comic&#160;import&#160;Comic</text><text class="terminal-884249335-r1" x="2147.2" y="215.2" textLength="12.2" clip-path="url(#terminal-884249335-line-8)">
-</text><text class="terminal-884249335-r1" x="0" y="239.6" textLength="951.6" clip-path="url(#terminal-884249335-line-9)">&#160;&#160;File&#160;&quot;/home/runner/work/Perdoo/Perdoo/perdoo/comic.py&quot;,&#160;line&#160;14,&#160;in&#160;&lt;module&gt;</text><text class="terminal-884249335-r1" x="2147.2" y="239.6" textLength="12.2" clip-path="url(#terminal-884249335-line-9)">
-</text><text class="terminal-884249335-r1" x="0" y="264" textLength="439.2" clip-path="url(#terminal-884249335-line-10)">&#160;&#160;&#160;&#160;from&#160;darkseid.archivers&#160;import&#160;(</text><text class="terminal-884249335-r1" x="2147.2" y="264" textLength="12.2" clip-path="url(#terminal-884249335-line-10)">
-</text><text class="terminal-884249335-r1" x="0" y="288.4" textLength="231.8" clip-path="url(#terminal-884249335-line-11)">&#160;&#160;&#160;&#160;...&lt;6&#160;lines&gt;...</text><text class="terminal-884249335-r1" x="2147.2" y="288.4" textLength="12.2" clip-path="url(#terminal-884249335-line-11)">
-</text><text class="terminal-884249335-r1" x="0" y="312.8" textLength="61" clip-path="url(#terminal-884249335-line-12)">&#160;&#160;&#160;&#160;)</text><text class="terminal-884249335-r1" x="2147.2" y="312.8" textLength="12.2" clip-path="url(#terminal-884249335-line-12)">
-</text><text class="terminal-884249335-r1" x="0" y="337.2" textLength="2147.2" clip-path="url(#terminal-884249335-line-13)">ImportError:&#160;cannot&#160;import&#160;name&#160;&#x27;SevenZipArchiver&#x27;&#160;from&#160;&#x27;darkseid.archivers&#x27;&#160;(/home/runner/work/Perdoo/Perdoo/.venv/lib/python3.13/site-packages/darkseid/archivers/__init__.py)</text><text class="terminal-884249335-r1" x="2147.2" y="337.2" textLength="12.2" clip-path="url(#terminal-884249335-line-13)">
+    <g class="terminal-1679728644-matrix">
+    <text class="terminal-1679728644-r2" x="976" y="20" textLength="12.2" clip-path="url(#terminal-1679728644-line-0)">
+</text><text class="terminal-1679728644-r3" x="12.2" y="44.4" textLength="85.4" clip-path="url(#terminal-1679728644-line-1)">Usage:&#160;</text><text class="terminal-1679728644-r1" x="97.6" y="44.4" textLength="390.4" clip-path="url(#terminal-1679728644-line-1)">Perdoo&#160;settings&#160;locate&#160;[OPTIONS]</text><text class="terminal-1679728644-r2" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-1679728644-line-1)">
+</text><text class="terminal-1679728644-r2" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-1679728644-line-2)">
+</text><text class="terminal-1679728644-r2" x="0" y="93.2" textLength="976" clip-path="url(#terminal-1679728644-line-3)">&#160;Display&#160;the&#160;path&#160;to&#160;the&#160;settings&#160;file.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1679728644-r2" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-1679728644-line-3)">
+</text><text class="terminal-1679728644-r2" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-1679728644-line-4)">
+</text><text class="terminal-1679728644-r2" x="976" y="142" textLength="12.2" clip-path="url(#terminal-1679728644-line-5)">
+</text><text class="terminal-1679728644-r4" x="0" y="166.4" textLength="24.4" clip-path="url(#terminal-1679728644-line-6)">╭─</text><text class="terminal-1679728644-r4" x="24.4" y="166.4" textLength="109.8" clip-path="url(#terminal-1679728644-line-6)">&#160;Options&#160;</text><text class="terminal-1679728644-r4" x="134.2" y="166.4" textLength="817.4" clip-path="url(#terminal-1679728644-line-6)">───────────────────────────────────────────────────────────────────</text><text class="terminal-1679728644-r4" x="951.6" y="166.4" textLength="24.4" clip-path="url(#terminal-1679728644-line-6)">─╮</text><text class="terminal-1679728644-r2" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-1679728644-line-6)">
+</text><text class="terminal-1679728644-r4" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-1679728644-line-7)">│</text><text class="terminal-1679728644-r5" x="24.4" y="190.8" textLength="12.2" clip-path="url(#terminal-1679728644-line-7)">-</text><text class="terminal-1679728644-r5" x="36.6" y="190.8" textLength="61" clip-path="url(#terminal-1679728644-line-7)">-help</text><text class="terminal-1679728644-r2" x="97.6" y="190.8" textLength="866.2" clip-path="url(#terminal-1679728644-line-7)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Show&#160;this&#160;message&#160;and&#160;exit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1679728644-r4" x="963.8" y="190.8" textLength="12.2" clip-path="url(#terminal-1679728644-line-7)">│</text><text class="terminal-1679728644-r2" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-1679728644-line-7)">
+</text><text class="terminal-1679728644-r4" x="0" y="215.2" textLength="976" clip-path="url(#terminal-1679728644-line-8)">╰──────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-1679728644-r2" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-1679728644-line-8)">
+</text><text class="terminal-1679728644-r2" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-1679728644-line-9)">
 </text>
     </g>
     </g>

--- a/docs/img/perdoo-settings-view.svg
+++ b/docs/img/perdoo-settings-view.svg
@@ -1,4 +1,4 @@
-<svg class="rich-terminal" viewBox="0 0 2166 391.59999999999997" xmlns="http://www.w3.org/2000/svg">
+<svg class="rich-terminal" viewBox="0 0 994 294.0" xmlns="http://www.w3.org/2000/svg">
     <!-- Generated with Rich https://www.textualize.io -->
     <style>
 
@@ -19,91 +19,79 @@
         font-weight: 700;
     }
 
-    .terminal-884249335-matrix {
+    .terminal-1054646449-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-884249335-title {
+    .terminal-1054646449-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-884249335-r1 { fill: #c5c8c6 }
+    .terminal-1054646449-r1 { fill: #c5c8c6;font-weight: bold }
+.terminal-1054646449-r2 { fill: #c5c8c6 }
+.terminal-1054646449-r3 { fill: #d0b344;font-weight: bold }
+.terminal-1054646449-r4 { fill: #868887 }
+.terminal-1054646449-r5 { fill: #68a0b3;font-weight: bold }
     </style>
 
     <defs>
-    <clipPath id="terminal-884249335-clip-terminal">
-      <rect x="0" y="0" width="2146.2" height="340.59999999999997" />
+    <clipPath id="terminal-1054646449-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="243.0" />
     </clipPath>
-    <clipPath id="terminal-884249335-line-0">
-    <rect x="0" y="1.5" width="2147.2" height="24.65"/>
+    <clipPath id="terminal-1054646449-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-1">
-    <rect x="0" y="25.9" width="2147.2" height="24.65"/>
+<clipPath id="terminal-1054646449-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-2">
-    <rect x="0" y="50.3" width="2147.2" height="24.65"/>
+<clipPath id="terminal-1054646449-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-3">
-    <rect x="0" y="74.7" width="2147.2" height="24.65"/>
+<clipPath id="terminal-1054646449-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-4">
-    <rect x="0" y="99.1" width="2147.2" height="24.65"/>
+<clipPath id="terminal-1054646449-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-5">
-    <rect x="0" y="123.5" width="2147.2" height="24.65"/>
+<clipPath id="terminal-1054646449-line-5">
+    <rect x="0" y="123.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-6">
-    <rect x="0" y="147.9" width="2147.2" height="24.65"/>
+<clipPath id="terminal-1054646449-line-6">
+    <rect x="0" y="147.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-7">
-    <rect x="0" y="172.3" width="2147.2" height="24.65"/>
+<clipPath id="terminal-1054646449-line-7">
+    <rect x="0" y="172.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-884249335-line-8">
-    <rect x="0" y="196.7" width="2147.2" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-884249335-line-9">
-    <rect x="0" y="221.1" width="2147.2" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-884249335-line-10">
-    <rect x="0" y="245.5" width="2147.2" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-884249335-line-11">
-    <rect x="0" y="269.9" width="2147.2" height="24.65"/>
-            </clipPath>
-<clipPath id="terminal-884249335-line-12">
-    <rect x="0" y="294.3" width="2147.2" height="24.65"/>
+<clipPath id="terminal-1054646449-line-8">
+    <rect x="0" y="196.7" width="976" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="2164" height="389.6" rx="8"/>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="292" rx="8"/>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-884249335-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-1054646449-clip-terminal)">
     
-    <g class="terminal-884249335-matrix">
-    <text class="terminal-884249335-r1" x="0" y="20" textLength="414.8" clip-path="url(#terminal-884249335-line-0)">Traceback&#160;(most&#160;recent&#160;call&#160;last):</text><text class="terminal-884249335-r1" x="2147.2" y="20" textLength="12.2" clip-path="url(#terminal-884249335-line-0)">
-</text><text class="terminal-884249335-r1" x="0" y="44.4" textLength="951.6" clip-path="url(#terminal-884249335-line-1)">&#160;&#160;File&#160;&quot;/home/runner/work/Perdoo/Perdoo/.venv/bin/Perdoo&quot;,&#160;line&#160;4,&#160;in&#160;&lt;module&gt;</text><text class="terminal-884249335-r1" x="2147.2" y="44.4" textLength="12.2" clip-path="url(#terminal-884249335-line-1)">
-</text><text class="terminal-884249335-r1" x="0" y="68.8" textLength="427" clip-path="url(#terminal-884249335-line-2)">&#160;&#160;&#160;&#160;from&#160;perdoo.__main__&#160;import&#160;app</text><text class="terminal-884249335-r1" x="2147.2" y="68.8" textLength="12.2" clip-path="url(#terminal-884249335-line-2)">
-</text><text class="terminal-884249335-r1" x="0" y="93.2" textLength="988.2" clip-path="url(#terminal-884249335-line-3)">&#160;&#160;File&#160;&quot;/home/runner/work/Perdoo/Perdoo/perdoo/__main__.py&quot;,&#160;line&#160;12,&#160;in&#160;&lt;module&gt;</text><text class="terminal-884249335-r1" x="2147.2" y="93.2" textLength="12.2" clip-path="url(#terminal-884249335-line-3)">
-</text><text class="terminal-884249335-r1" x="0" y="117.6" textLength="634.4" clip-path="url(#terminal-884249335-line-4)">&#160;&#160;&#160;&#160;from&#160;perdoo.cli&#160;import&#160;archive_app,&#160;settings_app</text><text class="terminal-884249335-r1" x="2147.2" y="117.6" textLength="12.2" clip-path="url(#terminal-884249335-line-4)">
-</text><text class="terminal-884249335-r1" x="0" y="142" textLength="1024.8" clip-path="url(#terminal-884249335-line-5)">&#160;&#160;File&#160;&quot;/home/runner/work/Perdoo/Perdoo/perdoo/cli/__init__.py&quot;,&#160;line&#160;3,&#160;in&#160;&lt;module&gt;</text><text class="terminal-884249335-r1" x="2147.2" y="142" textLength="12.2" clip-path="url(#terminal-884249335-line-5)">
-</text><text class="terminal-884249335-r1" x="0" y="166.4" textLength="646.6" clip-path="url(#terminal-884249335-line-6)">&#160;&#160;&#160;&#160;from&#160;perdoo.cli.archive&#160;import&#160;app&#160;as&#160;archive_app</text><text class="terminal-884249335-r1" x="2147.2" y="166.4" textLength="12.2" clip-path="url(#terminal-884249335-line-6)">
-</text><text class="terminal-884249335-r1" x="0" y="190.8" textLength="1012.6" clip-path="url(#terminal-884249335-line-7)">&#160;&#160;File&#160;&quot;/home/runner/work/Perdoo/Perdoo/perdoo/cli/archive.py&quot;,&#160;line&#160;8,&#160;in&#160;&lt;module&gt;</text><text class="terminal-884249335-r1" x="2147.2" y="190.8" textLength="12.2" clip-path="url(#terminal-884249335-line-7)">
-</text><text class="terminal-884249335-r1" x="0" y="215.2" textLength="414.8" clip-path="url(#terminal-884249335-line-8)">&#160;&#160;&#160;&#160;from&#160;perdoo.comic&#160;import&#160;Comic</text><text class="terminal-884249335-r1" x="2147.2" y="215.2" textLength="12.2" clip-path="url(#terminal-884249335-line-8)">
-</text><text class="terminal-884249335-r1" x="0" y="239.6" textLength="951.6" clip-path="url(#terminal-884249335-line-9)">&#160;&#160;File&#160;&quot;/home/runner/work/Perdoo/Perdoo/perdoo/comic.py&quot;,&#160;line&#160;14,&#160;in&#160;&lt;module&gt;</text><text class="terminal-884249335-r1" x="2147.2" y="239.6" textLength="12.2" clip-path="url(#terminal-884249335-line-9)">
-</text><text class="terminal-884249335-r1" x="0" y="264" textLength="439.2" clip-path="url(#terminal-884249335-line-10)">&#160;&#160;&#160;&#160;from&#160;darkseid.archivers&#160;import&#160;(</text><text class="terminal-884249335-r1" x="2147.2" y="264" textLength="12.2" clip-path="url(#terminal-884249335-line-10)">
-</text><text class="terminal-884249335-r1" x="0" y="288.4" textLength="231.8" clip-path="url(#terminal-884249335-line-11)">&#160;&#160;&#160;&#160;...&lt;6&#160;lines&gt;...</text><text class="terminal-884249335-r1" x="2147.2" y="288.4" textLength="12.2" clip-path="url(#terminal-884249335-line-11)">
-</text><text class="terminal-884249335-r1" x="0" y="312.8" textLength="61" clip-path="url(#terminal-884249335-line-12)">&#160;&#160;&#160;&#160;)</text><text class="terminal-884249335-r1" x="2147.2" y="312.8" textLength="12.2" clip-path="url(#terminal-884249335-line-12)">
-</text><text class="terminal-884249335-r1" x="0" y="337.2" textLength="2147.2" clip-path="url(#terminal-884249335-line-13)">ImportError:&#160;cannot&#160;import&#160;name&#160;&#x27;SevenZipArchiver&#x27;&#160;from&#160;&#x27;darkseid.archivers&#x27;&#160;(/home/runner/work/Perdoo/Perdoo/.venv/lib/python3.13/site-packages/darkseid/archivers/__init__.py)</text><text class="terminal-884249335-r1" x="2147.2" y="337.2" textLength="12.2" clip-path="url(#terminal-884249335-line-13)">
+    <g class="terminal-1054646449-matrix">
+    <text class="terminal-1054646449-r2" x="976" y="20" textLength="12.2" clip-path="url(#terminal-1054646449-line-0)">
+</text><text class="terminal-1054646449-r3" x="12.2" y="44.4" textLength="85.4" clip-path="url(#terminal-1054646449-line-1)">Usage:&#160;</text><text class="terminal-1054646449-r1" x="97.6" y="44.4" textLength="366" clip-path="url(#terminal-1054646449-line-1)">Perdoo&#160;settings&#160;view&#160;[OPTIONS]</text><text class="terminal-1054646449-r2" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-1054646449-line-1)">
+</text><text class="terminal-1054646449-r2" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-1054646449-line-2)">
+</text><text class="terminal-1054646449-r2" x="0" y="93.2" textLength="976" clip-path="url(#terminal-1054646449-line-3)">&#160;Display&#160;the&#160;current&#160;and&#160;default&#160;settings.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1054646449-r2" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-1054646449-line-3)">
+</text><text class="terminal-1054646449-r2" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-1054646449-line-4)">
+</text><text class="terminal-1054646449-r2" x="976" y="142" textLength="12.2" clip-path="url(#terminal-1054646449-line-5)">
+</text><text class="terminal-1054646449-r4" x="0" y="166.4" textLength="24.4" clip-path="url(#terminal-1054646449-line-6)">╭─</text><text class="terminal-1054646449-r4" x="24.4" y="166.4" textLength="109.8" clip-path="url(#terminal-1054646449-line-6)">&#160;Options&#160;</text><text class="terminal-1054646449-r4" x="134.2" y="166.4" textLength="817.4" clip-path="url(#terminal-1054646449-line-6)">───────────────────────────────────────────────────────────────────</text><text class="terminal-1054646449-r4" x="951.6" y="166.4" textLength="24.4" clip-path="url(#terminal-1054646449-line-6)">─╮</text><text class="terminal-1054646449-r2" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-1054646449-line-6)">
+</text><text class="terminal-1054646449-r4" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-1054646449-line-7)">│</text><text class="terminal-1054646449-r5" x="24.4" y="190.8" textLength="12.2" clip-path="url(#terminal-1054646449-line-7)">-</text><text class="terminal-1054646449-r5" x="36.6" y="190.8" textLength="61" clip-path="url(#terminal-1054646449-line-7)">-help</text><text class="terminal-1054646449-r2" x="97.6" y="190.8" textLength="866.2" clip-path="url(#terminal-1054646449-line-7)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Show&#160;this&#160;message&#160;and&#160;exit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1054646449-r4" x="963.8" y="190.8" textLength="12.2" clip-path="url(#terminal-1054646449-line-7)">│</text><text class="terminal-1054646449-r2" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-1054646449-line-7)">
+</text><text class="terminal-1054646449-r4" x="0" y="215.2" textLength="976" clip-path="url(#terminal-1054646449-line-8)">╰──────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-1054646449-r2" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-1054646449-line-8)">
+</text><text class="terminal-1054646449-r2" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-1054646449-line-9)">
 </text>
     </g>
     </g>

--- a/perdoo/comic.py
+++ b/perdoo/comic.py
@@ -156,9 +156,9 @@ class Comic:
             pad_count = len(str(len(files))) if files else 1
             for idx, filename in enumerate(files):
                 img_file = Path(filename)
-                new_file = img_file.with_name(f"{base_name}_{str(idx).zfill(pad_count)}")
+                new_file = img_file.with_stem(f"{base_name}_{str(idx).zfill(pad_count)}")
                 if new_file.stem != img_file.stem:
-                    LOGGER.info("Renaming '%s' to '%s'", img_file.stem, new_file.stem)
+                    LOGGER.info("Renaming '%s' to '%s'", img_file.name, new_file.name)
                     file_contents = source.read_file(archive_file=filename)
                     source.remove_files(filename_list=[filename])
                     source.write_file(archive_file=new_file.name, data=file_contents)

--- a/perdoo/metadata/_base.py
+++ b/perdoo/metadata/_base.py
@@ -4,6 +4,7 @@ import logging
 import re
 from collections.abc import Callable
 from pathlib import Path
+from typing import Literal
 
 from pydantic.alias_generators import to_pascal
 from pydantic_xml import BaseXmlModel
@@ -20,13 +21,13 @@ except ImportError:
 LOGGER = logging.getLogger(__name__)
 
 
-def sanitize(value: str | None) -> str | None:
+def sanitize(value: str | None, seperator: Literal["-", "_", ".", " "]) -> str | None:
     if not value:
         return value
     value = str(value)
-    value = re.sub(r"[^0-9a-zA-Z&! ]+", "", value.replace("-", " "))
+    value = re.sub(r"[^0-9a-zA-Z&! ]+", "", value.replace(seperator, " "))
     value = " ".join(value.split())
-    return value.replace(" ", "-")
+    return value.replace(" ", seperator)
 
 
 class PascalModel(
@@ -61,7 +62,12 @@ class PascalModel(
 
         CONSOLE.print(Panel.fit("\n".join(content_vals), title=type(self).__name__))
 
-    def evaluate_pattern(self, pattern_map: dict[str, Callable[[Self], str]], pattern: str) -> str:
+    def evaluate_pattern(
+        self,
+        pattern_map: dict[str, Callable[[Self], str]],
+        pattern: str,
+        seperator: Literal["-", "_", ".", " "],
+    ) -> str:
         def replace_match(match: re.Match) -> str:
             key = match.group("key")
             padding = match.group("padding")
@@ -73,7 +79,7 @@ class PascalModel(
 
             if padding and (isinstance(value, int) or (isinstance(value, str) and value.isdigit())):
                 return f"{int(value):0{padding}}"
-            return sanitize(value=value) or ""
+            return sanitize(value=value, seperator=seperator) or ""
 
         pattern_regex = re.compile(r"{(?P<key>[a-zA-Z-]+)(?::(?P<padding>\d+))?}")
         return pattern_regex.sub(replace_match, pattern)

--- a/perdoo/metadata/comic_info.py
+++ b/perdoo/metadata/comic_info.py
@@ -322,6 +322,7 @@ class ComicInfo(PascalModel):
                 Format.SINGLE_ISSUE.value: settings.single_issue or settings.default,
                 Format.TRADE_PAPERBACK.value: settings.trade_paperback or settings.default,
             }.get(self.format, settings.default),
+            seperator=settings.seperator,
         )
 
 

--- a/perdoo/metadata/metron_info.py
+++ b/perdoo/metadata/metron_info.py
@@ -386,6 +386,7 @@ class MetronInfo(PascalModel):
                 Format.SINGLE_ISSUE: settings.single_issue or settings.default,
                 Format.TRADE_PAPERBACK: settings.trade_paperback or settings.default,
             }.get(self.series.format, settings.default),
+            seperator=settings.seperator,
         )
 
 

--- a/perdoo/settings.py
+++ b/perdoo/settings.py
@@ -47,6 +47,7 @@ class MetronInfo(SettingsModel):
 
 
 class Naming(SettingsModel):
+    seperator: Literal["-", "_", ".", " "] = "-"
     default: str = "{publisher-name}/{series-name}-v{volume}/{series-name}-v{volume}_#{number:3}"
     annual: Annotated[str | None, BeforeValidator(blank_is_none)] = (
         "{publisher-name}/{series-name}-v{volume}/{series-name}-v{volume}_Annual_#{number:2}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
   "simyan >= 1.5.1",
   "tomli >= 2.2.1 ; python_version < '3.11'",
   "tomli-w >= 1.2.0",
-  "typer >= 0.16.0",
+  "typer >= 0.16.0"
 ]
 description = "Unify and organize your comic collection."
 dynamic = ["version"]

--- a/tests/naming_test.py
+++ b/tests/naming_test.py
@@ -5,10 +5,10 @@ from perdoo.settings import Naming
 
 
 def test_sanitize() -> None:
-    assert sanitize("Example Title!") == "Example-Title!"
-    assert sanitize("Example/Title: 123") == "ExampleTitle-123"
-    assert sanitize("!@#$%^&*()[]{};':,.<>?/") == "!&"
-    assert sanitize(None) is None
+    assert sanitize("Example Title!", seperator="-") == "Example-Title!"
+    assert sanitize("Example/Title: 123", seperator="-") == "ExampleTitle-123"
+    assert sanitize("!@#$%^&*()[]{};':,.<>?/", seperator="-") == "!&"
+    assert sanitize(None, seperator="-") is None
 
 
 def test_metron_info_default_naming() -> None:


### PR DESCRIPTION
- Fix renaming issue, with images inside archives
- Allow for a different seperator between words, options are: `-`, `_`, `.`, ` ` (space), closes #42 